### PR TITLE
Fix getting ABI from Sourcify metadata

### DIFF
--- a/src.ts/loaders.ts
+++ b/src.ts/loaders.ts
@@ -63,7 +63,7 @@ export class SourcifyABILoader implements ABILoader {
   async loadABI(address: string): Promise<any[]> {
     const url = "https://repo.sourcify.dev/contracts/full_match/1/" + address + "/metadata.json";
     const r = await fetchJson(url);
-    return JSON.parse(r.result);
+    return JSON.parse(r.result).output.abi;
   }
 }
 


### PR DESCRIPTION
The metadata file contains the abi under `outputs.abi` and that should be returned instead of the full metadata file.