### PR TITLE
Fix autoload EOA handling for viem; include empty name fields

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -49,3 +49,11 @@ online_test('autoload full', async ({ provider, env }) => {
 
   expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
 }, TIMEOUT);
+
+online_test('autoload non-contract', async ({ provider }) => {
+  const address = "0x0000000000000000000000000000000000000000"; // Random unverified contract
+  const { abi } = await autoload(address, {
+    provider: provider,
+  });
+  expect(abi).toStrictEqual([]);
+});

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -26,8 +26,8 @@ online_test('autoload selectors with experimental metadata', async ({ provider }
     signatureLookup: false,
     enableExperimentalMetadata: true,
   });
-  expect(abi).toContainEqual({"inputs": [{"type": "bytes"}], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function"});
-  expect(abi).toContainEqual({"inputs": [{"type": "bytes"}], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function"});
+  expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function"});
+  expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function"});
 }, TIMEOUT);
 
 

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -34,7 +34,7 @@ cached_test('README usage', async ({ provider, withCache }) => {
 
     expect(abi).toContainEqual({"hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f", "type": "event"});
     expect(abi).toContainEqual(
-      {"payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{"type": "bytes"}], "outputs": [{"type": "bytes"}]},
+      {"payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{"type": "bytes", "name": ""}], "outputs": [{"type": "bytes", "name": ""}]},
     );
   }
 

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -49,7 +49,7 @@ describe('loaders module', () => {
     const selectors = Object.values(selectorsFromABI(abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
     expect(selectors).toContain(sig);
-  })
+  }, 30000)
 
   online_test('SamczunSignatureLookup', async () => {
     const lookup = new SamczunSignatureLookup();

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -3,8 +3,8 @@ export type StateMutability = "nonpayable"|"payable"|"view"|"pure";
 export type ABIFunction = {
     type: "function"; // TODO: constructor, receive, fallback
     selector: string;
-    outputs?: {type: string, length?: number, name?: string}[];
-    inputs?: {type: string}[];
+    outputs?: {type: string, length?: number, name: string}[];
+    inputs?: {type: string, name: string}[];
     sig?: string;
     sigAlts?: string[];
     payable?: boolean;

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -81,7 +81,10 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
 
     // Load code, we need to disasm to find proxies
     onProgress("getCode", {address});
-    const program = disasm(await provider.getCode(address));
+    const bytecode = await provider.getCode(address)
+    if (!bytecode) return result; // Must be an EOA
+
+    const program = disasm(bytecode);
 
     // FIXME: Sort them in some reasonable way
     result.proxies = program.proxies;

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -203,10 +203,10 @@ export function abiFromBytecode(bytecodeOrProgram: string|Program): ABI {
         // Unfortunately we don't have better details about the type sizes, so we just return a dynamically-sized /shrug
         if (tags.has(opcodes.RETURN) || mutability === "view") {
             // FIXME: We assume outputs based on mutability, that's a hack.
-            funcABI.outputs = [{type: "bytes"}];
+            funcABI.outputs = [{type: "bytes", name: ""}];
         }
         if (tags.has(opcodes.CALLDATALOAD) || tags.has(opcodes.CALLDATASIZE) || tags.has(opcodes.CALLDATACOPY)) {
-            funcABI.inputs = [{type: "bytes"}];
+            funcABI.inputs = [{type: "bytes", name: ""}];
         }
 
         abi.push(funcABI);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    // ...
+    testTimeout: 15000,
   },
 })


### PR DESCRIPTION
- autoload: Test EOA, fix viem handling
- disasm: Include empty name fields for inputs and outputs