### PR TITLE
switch viem and ethersv5 provider order

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,11 @@ export function CompatibleProvider(provider: any): Provider {
     if (typeof provider.getStorage === "function") {
         return new Ethers6Provider(provider);
     }
-    if (typeof provider.getCode === "function") {
-        return new Ethers5Provider(provider);
-    }
     if (typeof provider.getBytecode === "function") {
         return new ViemProvider(provider);
+    }
+    if (typeof provider.getCode === "function") {
+        return new Ethers5Provider(provider);
     }
 
     throw new Error("Unsupported provider, please open an issue: https://github.com/shazow/whatsabi/issues");


### PR DESCRIPTION
Quick fix to make whatsabi compatible with the latest version of the viem public client. Ideally this should not rely on a deprecated function being present but for example on the "type" property of the provider being equal to "publicClient" (or anything else that can be used to difference providers).

Fixes issue #93 