### PR TITLE
fix: Viem compatability

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,6 +1,5 @@
-import { Fragment, FunctionFragment } from "ethers";
+import { Fragment, FunctionFragment, type Eip1193Provider } from "ethers";
 
-import type { AnyProvider } from "./types.js";
 import type { ABI, ABIFunction } from "./abi.js";
 import { type ProxyResolver, DiamondProxyResolver } from "./proxies.js";
 import type { ABILoader, SignatureLookup } from "./loaders.js";
@@ -10,234 +9,264 @@ import { defaultABILoader, defaultSignatureLookup } from "./loaders.js";
 import { abiFromBytecode, disasm } from "./disasm.js";
 
 function isAddress(address: string) {
-    return address.length === 42 && address.startsWith("0x") && Number(address) >= 0;
+	return (
+		address.length === 42 && address.startsWith("0x") && Number(address) >= 0
+	);
 }
 
 export const defaultConfig = {
-    onProgress: (_: string) => {},
-    onError: (phase: string, err: Error) => { console.error(phase + ":", err); return false; },
-}
+	onProgress: (_: string) => {},
+	onError: (phase: string, err: Error) => {
+		console.error(phase + ":", err);
+		return false;
+	},
+};
 
 export type AutoloadResult = {
-    address: string,
-    abi: ABI;
+	address: string;
+	abi: ABI;
 
-    // List of resolveable proxies detected in the contract
-    proxies: ProxyResolver[],
+	// List of resolveable proxies detected in the contract
+	proxies: ProxyResolver[];
 
-    // Follow proxies to next result.
-    // If multiple proxies were detected, some reasonable ordering of attempts will be made.
-    // Note: Some proxies operate relative to a specific selector (such as DiamondProxy facets), in this case we'll need to specify a selector that we care about.
-    followProxies?: (selector?: string) => Promise<AutoloadResult>,
-}
+	// Follow proxies to next result.
+	// If multiple proxies were detected, some reasonable ordering of attempts will be made.
+	// Note: Some proxies operate relative to a specific selector (such as DiamondProxy facets), in this case we'll need to specify a selector that we care about.
+	followProxies?: (selector?: string) => Promise<AutoloadResult>;
+};
 
 export type AutoloadConfig = {
-    provider: AnyProvider;
+	provider: Eip1193Provider;
 
-    abiLoader?: ABILoader|false;
-    signatureLookup?: SignatureLookup|false;
+	abiLoader?: ABILoader | false;
+	signatureLookup?: SignatureLookup | false;
 
-    // Hooks:
+	// Hooks:
 
-    // Called during various phases: resolveName, getCode, abiLoader, signatureLookup, followProxies
-    onProgress?: (phase: string, ...args: any[]) => void;
+	// Called during various phases: resolveName, getCode, abiLoader, signatureLookup, followProxies
+	onProgress?: (phase: string, ...args: any[]) => void;
 
-    // Called during any encountered errors during a given phase
-    onError?: (phase: string, error: Error) => boolean|void; // Return true-y to abort, undefined/false-y to continue
+	// Called during any encountered errors during a given phase
+	onError?: (phase: string, error: Error) => boolean | void; // Return true-y to abort, undefined/false-y to continue
 
-    // Called to resolve invalid addresses, uses provider's built-in resolver otherwise
-    addressResolver?: (name: string) => Promise<string>;
+	// Called to resolve invalid addresses, uses provider's built-in resolver otherwise
+	addressResolver?: (name: string) => Promise<string>;
 
-    // Settings:
+	// Settings:
 
-    // Enable following proxies automagically, if possible. Return the final result.
-    // Note that some proxies are relative to a specific selector (such as DiamondProxies), so they will not be followed
-    followProxies?: boolean;
+	// Enable following proxies automagically, if possible. Return the final result.
+	// Note that some proxies are relative to a specific selector (such as DiamondProxies), so they will not be followed
+	followProxies?: boolean;
 
-    // Enable pulling additional metadata from WhatsABI's static analysis, still unreliable
-    enableExperimentalMetadata?: boolean;
-}
+	// Enable pulling additional metadata from WhatsABI's static analysis, still unreliable
+	enableExperimentalMetadata?: boolean;
+};
 
 // auto is a convenience helper for doing All The Things to load an ABI of a contract.
-export async function autoload(address: string, config: AutoloadConfig): Promise<AutoloadResult> {
-    const onProgress = config.onProgress || defaultConfig.onProgress;
-    const onError = config.onError || defaultConfig.onError;
-    const provider = CompatibleProvider(config.provider);
+export async function autoload(
+	address: string,
+	config: AutoloadConfig,
+): Promise<AutoloadResult> {
+	const onProgress = config.onProgress || defaultConfig.onProgress;
+	const onError = config.onError || defaultConfig.onError;
+	const provider = CompatibleProvider(config.provider);
 
-    const result : AutoloadResult = {
-        address,
-        abi: [],
-        proxies: [],
-    };
+	const result: AutoloadResult = {
+		address,
+		abi: [],
+		proxies: [],
+	};
 
-    if (config === undefined) {
-        throw new Error("autoload: config is undefined, must include 'provider'");
-    }
-    let abiLoader = config.abiLoader;
-    if (abiLoader === undefined) abiLoader = defaultABILoader;
+	if (config === undefined) {
+		throw new Error("autoload: config is undefined, must include 'provider'");
+	}
+	let abiLoader = config.abiLoader;
+	if (abiLoader === undefined) abiLoader = defaultABILoader;
 
-    if (!isAddress(address)) {
-        onProgress("resolveName", {address});
-        if (config.addressResolver) {
-            address = await config.addressResolver(address);
-        } else {
-            address = await provider.getAddress(address);
-        }
-    }
+	if (!isAddress(address)) {
+		onProgress("resolveName", { address });
+		if (config.addressResolver) {
+			address = await config.addressResolver(address);
+		} else {
+			address = await provider.getAddress(address);
+		}
+	}
 
-    // Load code, we need to disasm to find proxies
-    onProgress("getCode", {address});
-    const bytecode = await provider.getCode(address)
-    if (!bytecode) return result; // Must be an EOA
+	// Load code, we need to disasm to find proxies
+	onProgress("getCode", { address });
+	const bytecode = await provider.getCode(address);
+	if (!bytecode) return result; // Must be an EOA
 
-    const program = disasm(bytecode);
+	const program = disasm(bytecode);
 
-    // FIXME: Sort them in some reasonable way
-    result.proxies = program.proxies;
+	// FIXME: Sort them in some reasonable way
+	result.proxies = program.proxies;
 
-    // Mapping of address-to-valid-selectors. Non-empty mapping values will prune ABIs to the selectors before returning.
-    // This is mainly to support multiple proxies and diamond proxies.
-    const facets: Record<string, string[]> = {
-        [address]: [],
-    };
+	// Mapping of address-to-valid-selectors. Non-empty mapping values will prune ABIs to the selectors before returning.
+	// This is mainly to support multiple proxies and diamond proxies.
+	const facets: Record<string, string[]> = {
+		[address]: [],
+	};
 
-    if (result.proxies.length === 1 && result.proxies[0] instanceof DiamondProxyResolver) {
-        onProgress("loadDiamondFacets", {address});
-        const diamondProxy = result.proxies[0] as DiamondProxyResolver;
-        const f = await diamondProxy.facets(provider, address);
-        Object.assign(facets, f);
+	if (
+		result.proxies.length === 1 &&
+		result.proxies[0] instanceof DiamondProxyResolver
+	) {
+		onProgress("loadDiamondFacets", { address });
+		const diamondProxy = result.proxies[0] as DiamondProxyResolver;
+		const f = await diamondProxy.facets(provider, address);
+		Object.assign(facets, f);
+	} else if (result.proxies.length > 0) {
+		result.followProxies = async function (
+			selector?: string,
+		): Promise<AutoloadResult> {
+			for (const resolver of result.proxies) {
+				onProgress("followProxies", { resolver: resolver, address });
+				const resolved = await resolver.resolve(provider, address, selector);
+				if (resolved !== undefined) return await autoload(resolved, config);
+			}
+			onError("followProxies", new Error("failed to resolve proxy"));
+			return result;
+		};
 
-    } else if (result.proxies.length > 0) {
-        result.followProxies = async function(selector?: string): Promise<AutoloadResult> {
-            for (const resolver of result.proxies) {
-                onProgress("followProxies", {resolver: resolver, address});
-                const resolved = await resolver.resolve(provider, address, selector);
-                if (resolved !== undefined) return await autoload(resolved, config);
-            }
-            onError("followProxies", new Error("failed to resolve proxy"));
-            return result;
-        };
+		if (config.followProxies) {
+			return await result.followProxies();
+		}
+	}
 
-        if (config.followProxies) {
-            return await result.followProxies();
-        }
-    }
+	if (abiLoader) {
+		// Attempt to load the ABI from a contract database, if exists
+		onProgress("abiLoader", { address, facets: Object.keys(facets) });
+		const loader = abiLoader;
+		try {
+			const addresses = Object.keys(facets);
+			const promises = addresses.map((addr) => loader.loadABI(addr));
+			const results = await Promise.all(promises);
+			const abis = Object.fromEntries(
+				results.map((abi, i) => {
+					return [addresses[i], abi];
+				}),
+			);
+			result.abi = pruneFacets(facets, abis);
+			if (result.abi.length > 0) return result;
+		} catch (error: any) {
+			// TODO: Catch useful errors
+			if (onError("abiLoad", error) === true) return result;
+		}
+	}
 
-    if (abiLoader) {
-        // Attempt to load the ABI from a contract database, if exists
-        onProgress("abiLoader", {address, facets: Object.keys(facets)});
-        const loader = abiLoader;
-        try {
-            const addresses = Object.keys(facets);
-            const promises = addresses.map(addr => loader.loadABI(addr));
-            const results = await Promise.all(promises);
-            const abis = Object.fromEntries(results.map((abi, i) => {
-                return [addresses[i], abi];
-            }));
-            result.abi = pruneFacets(facets, abis);
-            if (result.abi.length > 0) return result;
-        } catch (error: any) {
-            // TODO: Catch useful errors
-            if (onError("abiLoad", error) === true) return result;
-        }
-    }
+	// Load from code
+	onProgress("abiFromBytecode", { address });
+	result.abi = abiFromBytecode(program);
 
-    // Load from code
-    onProgress("abiFromBytecode", {address});
-    result.abi = abiFromBytecode(program);
+	if (!config.enableExperimentalMetadata) {
+		result.abi = stripUnreliableABI(result.abi);
+	}
 
-    if (!config.enableExperimentalMetadata) {
-        result.abi = stripUnreliableABI(result.abi);
-    }
+	// Add any extra ABIs we found from facets
+	result.abi.push(
+		...Object.values(facets)
+			.flat()
+			.map((selector) => {
+				return {
+					type: "function",
+					selector,
+				} as ABIFunction;
+			}),
+	);
 
-    // Add any extra ABIs we found from facets
-    result.abi.push(... Object.values(facets).flat().map(selector => {
-        return {
-            type: "function",
-            selector,
-        } as ABIFunction;
-    }));
+	let signatureLookup = config.signatureLookup;
+	if (signatureLookup === undefined) signatureLookup = defaultSignatureLookup;
+	if (!signatureLookup) return result; // Bail
 
-    let signatureLookup = config.signatureLookup;
-    if (signatureLookup === undefined) signatureLookup = defaultSignatureLookup;
-    if (!signatureLookup) return result; // Bail
+	// Load signatures from a database
+	onProgress("signatureLookup", { abiItems: result.abi.length });
 
-    // Load signatures from a database
-    onProgress("signatureLookup", {abiItems: result.abi.length});
+	let promises: Promise<void>[] = [];
 
-    let promises : Promise<void>[] = [];
+	for (const a of result.abi) {
+		if (a.type === "function") {
+			promises.push(
+				signatureLookup.loadFunctions(a.selector).then((r) => {
+					if (r.length >= 1) {
+						a.sig = r[0];
 
-    for (const a of result.abi) {
-        if (a.type === "function") {
-            promises.push(signatureLookup.loadFunctions(a.selector).then((r) => {
-                if (r.length >= 1) {
-                    a.sig = r[0];
+						// Let ethers.js extract as much metadata as it can from the signature
+						const extracted = JSON.parse(
+							Fragment.from("function " + a.sig).format("json"),
+						);
+						if (extracted.outputs.length === 0) {
+							// Outputs not included in signature databases -_- (unless something changed)
+							// Let whatsabi keep its best guess, if any.
+							delete extracted.outputs;
+						}
 
-                    // Let ethers.js extract as much metadata as it can from the signature
-                    const extracted = JSON.parse(Fragment.from("function " + a.sig).format("json"));
-                    if (extracted.outputs.length === 0) {
-                        // Outputs not included in signature databases -_- (unless something changed)
-                        // Let whatsabi keep its best guess, if any.
-                        delete(extracted.outputs);
-                    }
+						Object.assign(a, extracted);
+					}
+					if (r.length > 1) a.sigAlts = r.slice(1);
+				}),
+			);
+		} else if (a.type === "event") {
+			promises.push(
+				signatureLookup.loadEvents(a.hash).then((r) => {
+					if (r.length >= 1) {
+						a.sig = r[0];
 
-                    Object.assign(a, extracted)
-                }
-                if (r.length > 1) a.sigAlts = r.slice(1);
-            }));
-        } else if (a.type === "event") {
-            promises.push(signatureLookup.loadEvents(a.hash).then((r) => {
-                if (r.length >= 1) {
-                    a.sig = r[0];
+						// Let ethers.js extract as much metadata as it can from the signature
+						Object.assign(
+							a,
+							JSON.parse(Fragment.from("event " + a.sig).format("json")),
+						);
+					}
+					if (r.length > 1) a.sigAlts = r.slice(1);
+				}),
+			);
+		}
+	}
 
-                    // Let ethers.js extract as much metadata as it can from the signature
-                    Object.assign(a, JSON.parse(Fragment.from("event " + a.sig).format("json")))
-                }
-                if (r.length > 1) a.sigAlts = r.slice(1);
-            }));
-        }
-    }
+	await Promise.all(promises);
 
-    await Promise.all(promises);
-
-    return result;
+	return result;
 }
 
 function stripUnreliableABI(abi: ABI): ABI {
-    const r: ABI = [];
-    for (const a of abi) {
-        if (a.type !== "function") continue;
-        r.push({
-            type: "function",
-            selector: a.selector,
-        });
-    }
-    return r;
+	const r: ABI = [];
+	for (const a of abi) {
+		if (a.type !== "function") continue;
+		r.push({
+			type: "function",
+			selector: a.selector,
+		});
+	}
+	return r;
 }
 
-function pruneFacets(facets: Record<string, string[]>, abis: Record<string, ABI>): ABI {
-    const r: ABI = [];
-    for (const [addr, abi] of Object.entries(abis)) {
-        const allowSelectors = new Set(facets[addr]);
-        if (allowSelectors.size === 0) {
-            // Skip pruning if the mapping is empty
-            r.push(...abi);
-            continue;
-        }
-        for (let a of abi) {
-            if (a.type !== "function") {
-                r.push(a);
-                continue;
-            }
-            a = a as ABIFunction;
-            let selector = a.selector;
-            if (selector === undefined && a.name) {
-                selector = FunctionFragment.getSelector(a.name, a.inputs);
-            }
-            if (allowSelectors.has(selector)) {
-                r.push(a);
-            }
-        }
-    }
-    return r;
+function pruneFacets(
+	facets: Record<string, string[]>,
+	abis: Record<string, ABI>,
+): ABI {
+	const r: ABI = [];
+	for (const [addr, abi] of Object.entries(abis)) {
+		const allowSelectors = new Set(facets[addr]);
+		if (allowSelectors.size === 0) {
+			// Skip pruning if the mapping is empty
+			r.push(...abi);
+			continue;
+		}
+		for (let a of abi) {
+			if (a.type !== "function") {
+				r.push(a);
+				continue;
+			}
+			a = a as ABIFunction;
+			let selector = a.selector;
+			if (selector === undefined && a.name) {
+				selector = FunctionFragment.getSelector(a.name, a.inputs);
+			}
+			if (allowSelectors.has(selector)) {
+				r.push(a);
+			}
+		}
+	}
+	return r;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,158 +1,89 @@
-import { bytesToHex } from "./utils.js";
+import type { Eip1193Provider } from "ethers";
+import { BrowserProvider } from "ethers";
+import type { BlockTag } from "ethers";
 
-
-export interface StorageProvider {
-    getStorageAt(address: string, slot: number|string): Promise<string>
-}
-
-export interface CallProvider {
-    call(transaction: {to: string, data: string}): Promise<string>;
-}
-
-export interface CodeProvider {
-    getCode(address: string): Promise<string>;
-}
-
-export interface ENSProvider {
-    getAddress(name: string): Promise<string>;
-}
-
-export interface Provider extends StorageProvider, CallProvider, CodeProvider, ENSProvider {};
-
-export interface AnyProvider {}; // TODO: Can we narrow this more?
-
-
-// Abstract away web3 provider inconsistencies
-
-export function CompatibleProvider(provider: any): Provider {
-    if (typeof provider.getAddress === "function") {
-        return new GenericProvider(provider);
-    }
-    if (typeof provider.resolveName === "function") {
-        // Ethers-like
-        if (typeof provider.send === "function") {
-            return new EthersProvider(provider);
-        }
-        // Probably FallbackProvider or a different custom wrapper?
-        // Need to use higher-level functions.
-        return new GenericProvider(provider);
-    }
-    if (typeof provider.getEnsAddress === "function") {
-        return new ViemProvider(provider);
-    }
-    if (typeof provider.eth !== undefined) {
-        return new Web3Provider(provider);
-    }
-
-    throw new Error("Unsupported provider, please open an issue: https://github.com/shazow/whatsabi/issues");
-}
+export type Web3jsProvider = {
+	send: (method: string, params: unknown) => Promise<unknown>;
+};
+export type EthersProvider = Web3jsProvider;
+export type ViemProvider = Eip1193Provider;
+export { type Eip1193Provider };
 
 // RPCPRovider thesis is: let's stop trying to adapt to every RPC wrapper library's high-level functions
 // and instead have a discovery for the lowest-level RPC call function that we can use directly.
 // At least whenever possible. Higher-level functionality like getAddress is still tricky.
-abstract class RPCProvider implements Provider {
-    provider: any;
+export class RPCProvider implements Eip1193Provider {
+	static fromProvider(
+		provider: Web3jsProvider | EthersProvider | ViemProvider | Eip1193Provider,
+	) {
+		if ("request" in provider) {
+			return new RPCProvider(provider);
+		}
+		if ("send" in provider) {
+			return RPCProvider.fromWeb3jsProvider(provider);
+		}
+		throw new Error("Unsupported provider");
+	}
+	static fromWeb3jsProvider(provider: {
+		send: (method: string, params: unknown) => Promise<unknown>;
+	}) {
+		const eip1193Provider: Eip1193Provider = {
+			request: ({ method, params }) => provider.send(method, params),
+		};
+		return new RPCProvider(eip1193Provider);
+	}
 
-    constructor(provider: any) {
-        this.provider = provider;
-    }
+	static fromEthersProvider(provider: {
+		send: (method: string, params: unknown) => Promise<unknown>;
+	}) {
+		const eip1193Provider: Eip1193Provider = {
+			request: ({ method, params }) => provider.send(method, params),
+		};
+		return new RPCProvider(eip1193Provider);
+	}
 
-    abstract send(method: string, params: Array<any>): Promise<any>;
+	static fromViemProvider(provider: Eip1193Provider) {
+		return new RPCProvider(provider);
+	}
 
-    getStorageAt(address: string, slot: number|string): Promise<string> {
-        if (typeof slot === "number") {
-            slot = bytesToHex(slot);
-        }
-        return this.send("eth_getStorageAt", [address, slot, "latest"]);
-    }
+	public readonly provider: Eip1193Provider;
 
-    call(transaction: {to: string, data: string}): Promise<string> {
-        return this.send("eth_call", [
-            {
-                from: "0x0000000000000000000000000000000000000001",
-                to: transaction.to,
-                data: transaction.data,
-            },
-            "latest"
-        ]);
-    }
+	public readonly request: Eip1193Provider["request"];
 
-    getCode(address: string): Promise<string> {
-        return this.send("eth_getCode", [address, "latest"]);
-    }
+	private readonly ethersProvider: BrowserProvider;
 
-    abstract getAddress(name: string): Promise<string>;
+	constructor(provider: Eip1193Provider) {
+		this.provider = provider;
+		this.request = provider.request.bind(provider);
+		this.ethersProvider = new BrowserProvider(provider);
+	}
 
-}
+	getStorageAt(
+		address: string,
+		slot: number | string,
+		blockTag: BlockTag = "latest",
+	): Promise<string> {
+		return this.ethersProvider.getStorage(address, slot, blockTag);
+	}
 
-class GenericProvider implements Provider {
-    provider: any;
+	call(transaction: {
+		to: string;
+		data: string;
+		blockTag?: BlockTag;
+	}): Promise<string> {
+		return this.ethersProvider.call({
+			from: "0x0000000000000000000000000000000000000001",
+			to: transaction.to,
+			data: transaction.data,
+			blockTag: transaction.blockTag ?? "latest",
+		});
+	}
 
-    constructor(provider: any) {
-        this.provider = provider;
-    }
+	getCode(address: string, blockTag: BlockTag = "latest"): Promise<string> {
+		return this.ethersProvider.getCode(address, blockTag);
+	}
 
-    getStorageAt(address: string, slot: number|string): Promise<string> {
-        if ("getStorageAt" in this.provider) {
-            return this.provider.getStorageAt(address, slot);
-        }
-        return this.provider.getStorage(address, slot);
-    }
-
-    call(transaction: {to: string, data: string}): Promise<string> {
-        return this.provider.call(transaction);
-    }
-
-    getCode(address: string): Promise<string> {
-        return this.provider.getCode(address);
-    }
-
-    getAddress(name: string): Promise<string> {
-        return this.provider.getAddress(name);
-    }
-}
-
-type JSONRPCResponse = {
-    result?: string,
-    error?: {
-        id: number,
-        message: string,
-    };
-};
-
-class Web3Provider extends RPCProvider {
-    send(method: string, params: Array<any>): Promise<any> {
-        // this.provider is the web3 instance, we need web3.provider
-        const r = this.provider.currentProvider.request({method, params, "jsonrpc": "2.0", id: "1"});
-        return r.then((resp : JSONRPCResponse) => {
-            if (resp.result) return resp.result;
-            else if (resp.error) throw new Error(resp.error.message);
-            return resp;
-        });
-    }
-
-    getAddress(name: string): Promise<string> {
-        return this.provider.eth.ens.getAddress(name)
-    }
-}
-
-
-class EthersProvider extends RPCProvider {
-    send(method: string, params: Array<any>): Promise<any> {
-        return this.provider.send(method, params);
-    }
-
-    getAddress(name: string): Promise<string> {
-        return this.provider.resolveName(name);
-    }
-}
-
-class ViemProvider extends RPCProvider {
-    send(method: string, params: Array<any>): Promise<any> {
-        return this.provider.transport.request({method, params});
-    }
-
-    getAddress(name: string): Promise<string> {
-        return this.provider.getEnsAddress({name});
-    }
+	getAddress(name: string): Promise<string | null> {
+		return this.ethersProvider.resolveName(name);
+	}
 }


### PR DESCRIPTION
Viem only works if we pass in a public client. This refactors the adapters to be significantly looser with regard to their type.

- We only accept EIP-1193 providers now
- We offer adapters to turn web3 providers into EIP-1193 providers though just like before
- Internally we only use ethers consistentally we don't use each providers specific implementation of things like getCode

## TODO

- [ ] Need to update everything that broke from this change
- [ ] Fix formatting etc.