### PR TITLE
providers: Fix viem non-public clients, wrap autoload ENS error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Quick start:
 import { ethers } from "ethers";
 import { whatsabi } from "@shazow/whatsabi";
 
-const provider = ethers.getDefaultProvider(); // substitute with your fav provider
+// Works with any provider (or client) library like Ethers.js, Viem, or Web3.js!
+const provider = ethers.getDefaultProvider();
 const address = "0x00000000006c3852cbEf3e08E8dF289169EdE581"; // Or your fav contract address
 
 // Quick-start:
@@ -42,7 +43,19 @@ console.log(result.abi);
 // -> [ ... ]
 ```
 
-Breaking it down:
+Another quick example with Viem:
+
+```typescript
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+import { whatsabi } from "@shazow/whatsabi";
+ 
+const client = createPublicClient({ chain: mainnet, transport: http() })
+const result = await whatsabi.autoload(address, { provider: client });
+```
+
+
+Breaking it down, here's what autoload is doing on the inside:
 
 ```typescript
 const code = await provider.getCode(address); // Load the bytecode

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -8,62 +8,62 @@ import { test, online_test } from "./env";
 const TIMEOUT = 15000;
 
 test('autoload throws typed error', async () => {
-  // @ts-expect-error: Expected 2 arguments, but got 1
-  await expect(autoload("0xf00")).rejects.toThrow(/config is undefined/);
+    // @ts-expect-error: Expected 2 arguments, but got 1
+    await expect(autoload("0xf00")).rejects.toThrow(/config is undefined/);
 
-  const fakeProvider = {
-    request: () => {},
-  }
-  await expect(autoload("abc.eth", { provider: fakeProvider })).rejects.toThrow(/Failed to resolve ENS/);
+    const fakeProvider = {
+        request: () => {},
+    }
+    await expect(autoload("abc.eth", { provider: fakeProvider })).rejects.toThrow(/Failed to resolve ENS/);
 });
 
 online_test('autoload selectors', async ({ provider }) => {
-  const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
-  const { abi } = await autoload(address, {
-    provider: provider,
-    abiLoader: false,
-    signatureLookup: false,
-  });
-  expect(abi).toContainEqual({"selector": "0x6dbf2fa0", "type": "function"});
-  expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
+    const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
+    const { abi } = await autoload(address, {
+        provider: provider,
+        abiLoader: false,
+        signatureLookup: false,
+    });
+    expect(abi).toContainEqual({"selector": "0x6dbf2fa0", "type": "function"});
+    expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
 }, TIMEOUT);
 
 online_test('autoload selectors with experimental metadata', async ({ provider }) => {
-  const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
-  const { abi } = await autoload(address, {
-    provider: provider,
-    abiLoader: false,
-    signatureLookup: false,
-    enableExperimentalMetadata: true,
-  });
-  expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function"});
-  expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function"});
+    const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
+    const { abi } = await autoload(address, {
+        provider: provider,
+        abiLoader: false,
+        signatureLookup: false,
+        enableExperimentalMetadata: true,
+    });
+    expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function"});
+    expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function"});
 }, TIMEOUT);
 
 
 online_test('autoload full', async ({ provider, env }) => {
-  const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
-  const { abi } = await autoload(address, {
-    provider: provider,
-    abiLoader: new whatsabi.loaders.MultiABILoader([
-      new whatsabi.loaders.SourcifyABILoader(),
-      new whatsabi.loaders.EtherscanABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
-    ]),
-    signatureLookup: new whatsabi.loaders.MultiSignatureLookup([
-      new whatsabi.loaders.OpenChainSignatureLookup(),
-      new whatsabi.loaders.FourByteSignatureLookup(),
-    ]),
-    //onProgress: (phase: string, ...args: any[]) => { console.debug("PROGRESS", phase, args); },
-  });
-  expect(abi).toContainEqual({"constant": false, "inputs": [{"type": "address", "name": ""}, {"type": "uint256", "name": ""}, {"type": "bytes", "name": ""}], "name": "call", "payable": false, "selector": "0x6dbf2fa0", "sig": "call(address,uint256,bytes)", "type": "function"})
+    const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
+    const { abi } = await autoload(address, {
+        provider: provider,
+        abiLoader: new whatsabi.loaders.MultiABILoader([
+            new whatsabi.loaders.SourcifyABILoader(),
+            new whatsabi.loaders.EtherscanABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
+        ]),
+        signatureLookup: new whatsabi.loaders.MultiSignatureLookup([
+            new whatsabi.loaders.OpenChainSignatureLookup(),
+            new whatsabi.loaders.FourByteSignatureLookup(),
+        ]),
+        //onProgress: (phase: string, ...args: any[]) => { console.debug("PROGRESS", phase, args); },
+    });
+    expect(abi).toContainEqual({"constant": false, "inputs": [{"type": "address", "name": ""}, {"type": "uint256", "name": ""}, {"type": "bytes", "name": ""}], "name": "call", "payable": false, "selector": "0x6dbf2fa0", "sig": "call(address,uint256,bytes)", "type": "function"})
 
-  expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
+    expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
 }, TIMEOUT);
 
 online_test('autoload non-contract', async ({ provider }) => {
-  const address = "0x0000000000000000000000000000000000000000"; // Random unverified contract
-  const { abi } = await autoload(address, {
-    provider: provider,
-  });
-  expect(abi).toStrictEqual([]);
+    const address = "0x0000000000000000000000000000000000000000"; // Random unverified contract
+    const { abi } = await autoload(address, {
+        provider: provider,
+    });
+    expect(abi).toStrictEqual([]);
 });

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -10,6 +10,11 @@ const TIMEOUT = 15000;
 test('autoload throws typed error', async () => {
   // @ts-expect-error: Expected 2 arguments, but got 1
   await expect(autoload("0xf00")).rejects.toThrow(/config is undefined/);
+
+  const fakeProvider = {
+    request: () => {},
+  }
+  await expect(autoload("abc.eth", { provider: fakeProvider })).rejects.toThrow(/Failed to resolve ENS/);
 });
 
 online_test('autoload selectors', async ({ provider }) => {

--- a/src/__tests__/env.ts
+++ b/src/__tests__/env.ts
@@ -1,7 +1,7 @@
 import { test, describe } from 'vitest';
 
 import { ethers } from "ethers";
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, createWalletClient, http } from 'viem';
 import { Web3 } from "web3";
 
 import { withCache } from "../internal/filecache";
@@ -23,10 +23,11 @@ const provider = CompatibleProvider(function() {
         rpc_url = "https://mainnet.infura.io/v3/" + env.INFURA_API_KEY;
     }
 
-    if (env.PROVIDER === "viem") {
-        return createPublicClient({
-            transport: http(rpc_url ?? DEFAULT_PUBLIC_RPC),
-        });
+    if (env.PROVIDER?.startsWith("viem")) {
+        const transport = http(rpc_url ?? DEFAULT_PUBLIC_RPC)
+        if (env.PROVIDER.endsWith("transport")) return transport;
+        if (env.PROVIDER.endsWith("publicClient")) return createPublicClient({ transport });
+        return createWalletClient({ transport });
     }
 
     if (env.PROVIDER === "web3") {

--- a/src/__tests__/env.ts
+++ b/src/__tests__/env.ts
@@ -24,8 +24,7 @@ const provider = CompatibleProvider(function() {
     }
 
     if (env.PROVIDER?.startsWith("viem")) {
-        const transport = http(rpc_url ?? DEFAULT_PUBLIC_RPC)
-        if (env.PROVIDER.endsWith("transport")) return transport;
+        const transport = http(rpc_url ?? DEFAULT_PUBLIC_RPC);
         if (env.PROVIDER.endsWith("publicClient")) return createPublicClient({ transport });
         return createWalletClient({ transport });
     }

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -8,95 +8,95 @@ const TIMEOUT = 25000;
 
 cached_test('README usage', async ({ provider, withCache }) => {
 
-  const address = "0x00000000006c3852cbEf3e08E8dF289169EdE581"; // Or your fav contract address
+    const address = "0x00000000006c3852cbEf3e08E8dF289169EdE581"; // Or your fav contract address
 
-  const code = await withCache(
-    `${address}_code`,
-    async () => {
-      return await provider.getCode(address)
-    },
-  )
+    const code = await withCache(
+        `${address}_code`,
+        async () => {
+            return await provider.getCode(address)
+        },
+    )
 
-  const selectors = whatsabi.selectorsFromBytecode(code); // Get the callable selectors
-  
-  // console.log(selectors); // ["0x06fdde03", "0x46423aa7", "0x55944a42", ...]
-  expect(selectors).toEqual(expect.arrayContaining(["0x06fdde03", "0x46423aa7", "0x55944a42"]));
+    const selectors = whatsabi.selectorsFromBytecode(code); // Get the callable selectors
+    
+    // console.log(selectors); // ["0x06fdde03", "0x46423aa7", "0x55944a42", ...]
+    expect(selectors).toEqual(expect.arrayContaining(["0x06fdde03", "0x46423aa7", "0x55944a42"]));
 
-  {
-    const abi = whatsabi.abiFromBytecode(code);
-    // console.log(abi);
-    // [
-    //    {"type": "event", "hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f"},
-    //    {"type": "function", "payable": true, "selector": "0x06fdde03"},
-    //    {"type": "function", "payable": true, "selector": "0x46423aa7"},
-    //    ...
-    // ]
+    {
+        const abi = whatsabi.abiFromBytecode(code);
+        // console.log(abi);
+        // [
+        //        {"type": "event", "hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f"},
+        //        {"type": "function", "payable": true, "selector": "0x06fdde03"},
+        //        {"type": "function", "payable": true, "selector": "0x46423aa7"},
+        //        ...
+        // ]
 
-    expect(abi).toContainEqual({"hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f", "type": "event"});
-    expect(abi).toContainEqual(
-      {"payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{"type": "bytes", "name": ""}], "outputs": [{"type": "bytes", "name": ""}]},
-    );
-  }
+        expect(abi).toContainEqual({"hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f", "type": "event"});
+        expect(abi).toContainEqual(
+            {"payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{"type": "bytes", "name": ""}], "outputs": [{"type": "bytes", "name": ""}]},
+        );
+    }
 
-  const signatureLookup = new whatsabi.loaders.OpenChainSignatureLookup();
-  {
-    const sig = await signatureLookup.loadFunctions("0x06fdde03");
-    expect(sig).toStrictEqual(["name()"]);
-  }
-  {
-    const sig = await signatureLookup.loadFunctions("0x46423aa7");
-    expect(sig).toStrictEqual(["getOrderStatus(bytes32)"]);
-  }
+    const signatureLookup = new whatsabi.loaders.OpenChainSignatureLookup();
+    {
+        const sig = await signatureLookup.loadFunctions("0x06fdde03");
+        expect(sig).toStrictEqual(["name()"]);
+    }
+    {
+        const sig = await signatureLookup.loadFunctions("0x46423aa7");
+        expect(sig).toStrictEqual(["getOrderStatus(bytes32)"]);
+    }
 
-  const event = await signatureLookup.loadEvents("0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f");
-  expect(event).toContainEqual("CounterIncremented(uint256,address)")
+    const event = await signatureLookup.loadEvents("0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f");
+    expect(event).toContainEqual("CounterIncremented(uint256,address)")
 }, TIMEOUT)
 
 online_test('README autoload', async ({ provider }) => {
-  const address = "0x00000000006c3852cbEf3e08E8dF289169EdE581"; // Or your fav contract address
+    const address = "0x00000000006c3852cbEf3e08E8dF289169EdE581"; // Or your fav contract address
 
-  {
-    let result = await whatsabi.autoload(address, {
-      provider: provider,
+    {
+        let result = await whatsabi.autoload(address, {
+            provider: provider,
 
-      // * Optional loaders:
-      // abiLoader: whatsabi.loaders.defaultABILoader,
-      // signatureLoader: whatsabi.loaders.defaultSignatureLookup,
+            // * Optional loaders:
+            // abiLoader: whatsabi.loaders.defaultABILoader,
+            // signatureLoader: whatsabi.loaders.defaultSignatureLookup,
 
-      // There is a handy helper for adding the default loaders but with your own settings
-      ... whatsabi.loaders.defaultsWithEnv({
-        SOURCIFY_CHAIN_ID: 42161,
-        ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
-        //ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
-      }),
+            // There is a handy helper for adding the default loaders but with your own settings
+            ... whatsabi.loaders.defaultsWithEnv({
+                SOURCIFY_CHAIN_ID: 42161,
+                ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
+                //ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
+            }),
 
-      // * Optional hooks:
-      // onProgress: (phase: string) => { ... }
-      // onError: (phase: string, context: any) => { ... }
+            // * Optional hooks:
+            // onProgress: (phase: string) => { ... }
+            // onError: (phase: string, context: any) => { ... }
 
-      onProgress: (phase) => console.log("autoload progress", phase),
-      onError: (phase, context) => console.log("autoload error", phase, context),
+            onProgress: (phase) => console.log("autoload progress", phase),
+            onError: (phase, context) => console.log("autoload error", phase, context),
 
-      // * Optional settings:
-      // followProxies: false,
-      // enableExperimentalMetadata: false,
-    });
-    expect(result.abi).toContainEqual(
-      // 'function name() pure returns (string contractName)'
-      {"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"contractName","type":"string"}],"stateMutability":"pure","type":"function"}
-    );
+            // * Optional settings:
+            // followProxies: false,
+            // enableExperimentalMetadata: false,
+        });
+        expect(result.abi).toContainEqual(
+            // 'function name() pure returns (string contractName)'
+            {"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"contractName","type":"string"}],"stateMutability":"pure","type":"function"}
+        );
 
-    if (result.followProxies) {
-        result = await result.followProxies();
+        if (result.followProxies) {
+                result = await result.followProxies();
+        }
     }
-  }
 
-  {
-      const { abi, address } = await whatsabi.autoload("0x4f8AD938eBA0CD19155a835f617317a6E788c868", {
-          provider,
-          followProxies: true,
-      });
-      expect(abi.length).toBeGreaterThan(0);
-      expect(address).toBe("0x964f84048f0d9bb24b82413413299c0a1d61ea9f");
-  }
+    {
+            const { abi, address } = await whatsabi.autoload("0x4f8AD938eBA0CD19155a835f617317a6E788c868", {
+                    provider,
+                    followProxies: true,
+            });
+            expect(abi.length).toBeGreaterThan(0);
+            expect(address).toBe("0x964f84048f0d9bb24b82413413299c0a1d61ea9f");
+    }
 }, TIMEOUT);

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -101,7 +101,14 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
         if (config.addressResolver) {
             address = await config.addressResolver(address);
         } else {
-            address = await provider.getAddress(address);
+            try {
+                address = await provider.getAddress(address);
+            } catch (err) {
+                throw new errors.AutoloadError(`Failed to resolve ENS address using provider.getAddress, try supplying your own resolver in AutoloadConfig by specifying addressResolver`, {
+                    context: { address },
+                    cause: err as Error,
+                });
+            }
         }
     }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -170,6 +170,7 @@ export class Web3ProviderError extends errors.ProviderError { };
 
 class EthersProvider extends RPCProvider {
     request(args: EIP1193RequestArguments): Promise<any> {
+        // Fun fact: Before 2020, EIP1193 draft had used .send(method, params) instead of .request({method, params})
         return this.provider.send(args.method, args.params);
     }
 


### PR DESCRIPTION
- Reformatted some tests, ignore whitespace plz
- Added explicit viem example to the README, so it's more clear that whatsabi is not ethers-only (fixes #106)
- Added AutoloadError wrapper for when provider does not support ENS with instructions to specify addressResolver
- Added test for passing in a fake provider without ENS support
- Refactored the provider abstraction to be a bit more EIP-1193-centric.
- Default viem test suite now runs with a `createWalletClient` instead of a `createPublicClient`
- Fixes #105 ?

Obsoletes #104