### PR TITLE
loaders: Add getSources() to ContractResult

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ build:
 docs:
 	pnpm build:docs
 
+serve-docs:
+	python -m http.server -d ./docs
+
 watch:
 	tsc --project tsconfig.esm.json -w
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ const loader = new whatsabi.loaders.MultiABILoader([
 const { abi, name, /* ... other metadata */ } = await loader.getContract(address));
 ```
 
+See [whatsabi.loaders](https://shazow.github.io/whatsabi/modules/whatsabi.loaders.html) for more examples of what our loaders can do, like loading verified contract source code and compiler settings.
+
 All together with our do-all-the-things helper:
 
 ```typescript

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -18,7 +18,7 @@ cached_test('README usage', async ({ provider, withCache }) => {
     )
 
     const selectors = whatsabi.selectorsFromBytecode(code); // Get the callable selectors
-    
+
     // console.log(selectors); // ["0x06fdde03", "0x46423aa7", "0x55944a42", ...]
     expect(selectors).toEqual(expect.arrayContaining(["0x06fdde03", "0x46423aa7", "0x55944a42"]));
 
@@ -32,9 +32,9 @@ cached_test('README usage', async ({ provider, withCache }) => {
         //        ...
         // ]
 
-        expect(abi).toContainEqual({"hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f", "type": "event"});
+        expect(abi).toContainEqual({ "hash": "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f", "type": "event" });
         expect(abi).toContainEqual(
-            {"payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{"type": "bytes", "name": ""}], "outputs": [{"type": "bytes", "name": ""}]},
+            { "payable": true, "selector": "0xb3a34c4c", "type": "function", "stateMutability": "payable", "inputs": [{ "type": "bytes", "name": "" }], "outputs": [{ "type": "bytes", "name": "" }] },
         );
     }
 
@@ -64,7 +64,7 @@ online_test('README autoload', async ({ provider }) => {
             // signatureLoader: whatsabi.loaders.defaultSignatureLookup,
 
             // There is a handy helper for adding the default loaders but with your own settings
-            ... whatsabi.loaders.defaultsWithEnv({
+            ...whatsabi.loaders.defaultsWithEnv({
                 SOURCIFY_CHAIN_ID: 42161,
                 ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
                 //ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
@@ -83,20 +83,28 @@ online_test('README autoload', async ({ provider }) => {
         });
         expect(result.abi).toContainEqual(
             // 'function name() pure returns (string contractName)'
-            {"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"contractName","type":"string"}],"stateMutability":"pure","type":"function"}
+            { "inputs": [], "name": "name", "outputs": [{ "internalType": "string", "name": "contractName", "type": "string" }], "stateMutability": "pure", "type": "function" }
         );
 
         if (result.followProxies) {
-                result = await result.followProxies();
+            result = await result.followProxies();
         }
     }
 
     {
-            const { abi, address } = await whatsabi.autoload("0x4f8AD938eBA0CD19155a835f617317a6E788c868", {
-                    provider,
-                    followProxies: true,
-            });
-            expect(abi.length).toBeGreaterThan(0);
-            expect(address).toBe("0x964f84048f0d9bb24b82413413299c0a1d61ea9f");
+        const { abi, address } = await whatsabi.autoload("0x4f8AD938eBA0CD19155a835f617317a6E788c868", {
+            provider,
+            followProxies: true,
+        });
+        expect(abi.length).toBeGreaterThan(0);
+        expect(address).toBe("0x964f84048f0d9bb24b82413413299c0a1d61ea9f");
     }
+
+    {
+        // Check defaultsWithEnv decomposition
+        const { abiLoader, signatureLookup } = whatsabi.loaders.defaultsWithEnv({});
+        expect(abiLoader).toBeDefined();
+        expect(signatureLookup).toBeDefined();
+    }
+
 }, TIMEOUT);

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -87,10 +87,14 @@ describe('loaders module', () => {
 
   online_test('EtherscanABILoader_getContract', async () => {
     const loader = new EtherscanABILoader({ apiKey: process.env["ETHERSCAN_API_KEY"] });
-    const {abi} = await loader.getContract("0x7a250d5630b4cf539739df2c5dacb4c659f2488d");
-    const selectors = Object.values(selectorsFromABI(abi));
+    const result = await loader.getContract("0x7a250d5630b4cf539739df2c5dacb4c659f2488d");
+    const selectors = Object.values(selectorsFromABI(result.abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
     expect(selectors).toContain(sig);
+
+    const sources = result.getSources && await result.getSources();
+    expect(sources[""]).toContain("pragma solidity");
+
   }, SLOW_ETHERSCAN_TIMEOUT)
 
   online_test('EtherscanABILoader_getContract_UniswapV3Factory', async () => {
@@ -146,11 +150,14 @@ describe('loaders module', () => {
     const loader = new MultiABILoader([
       new EtherscanABILoader({ apiKey: process.env["ETHERSCAN_API_KEY"] }),
     ]);
-    const {abi, name} = await loader.getContract(address);
+    const res = await loader.getContract(address);
     const sig = "owner()";
-    const selectors = Object.values(selectorsFromABI(abi));
+    const selectors = Object.values(selectorsFromABI(res.abi));
     expect(selectors).toContain(sig);
-    expect(name).toEqual("UniswapV3Factory");
+    expect(res.name).toEqual("UniswapV3Factory");
+
+    const sources = res.getSources && await res.getSources();
+    expect(sources["contracts/libraries/UnsafeMath.sol"]).contains("pragma solidity");
   }, SLOW_ETHERSCAN_TIMEOUT);
 
   online_test('SamczunSignatureLookup', async () => {

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -40,7 +40,7 @@ describe('loaders module', () => {
 
   online_test('SourcifyABILoader', async () => {
     const loader = new SourcifyABILoader();
-    const abi = await loader.loadABI("0x7a250d5630b4cf539739df2c5dacb4c659f2488d");
+    const abi = await loader.loadABI("0x7a250d5630b4cf539739df2c5dacb4c659f2488d"); // Unchecksummed address
     const selectors = Object.values(selectorsFromABI(abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
     expect(selectors).toContain(sig);

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,3 +1,29 @@
+/**
+ * @module loaders
+ * @example
+ * Verified contract source code:
+ * ```ts
+ * const loader = whatsabi.loaders.defaultsWithEnv(env);
+ * const result = await loader.getContract(address);
+ * const sources = await result.getSources();
+ *
+ * for (const s of sources) {
+ *   console.log(s.path, " -> ", s.content + "...");
+ * }
+ * ```
+ *
+ * @example
+ * Combine loaders with custom settings behind a single interface, or use {@link defaultsWithEnv} as a shortcut for this.
+ * ```ts
+ * const loader = new whatsabi.loaders.MultiABILoader([
+ *   new whatsabi.loaders.SourcifyABILoader({ chainId: 8453 }),
+ *   new whatsabi.loaders.EtherscanABILoader({
+ *     baseURL: "https://api.basescan.org/api",
+ *     apiKey: "...", // Replace the value with your API key
+ *   }),
+ * ]);
+ * ```
+ */
 import { fetchJSON } from "./utils.js";
 import * as errors from "./errors.js";
 
@@ -217,7 +243,7 @@ export class SourcifyABILoader implements ABILoader {
     async #loadContract(url: string): Promise<ContractResult> {
         try {
             const r = await fetchJSON(url);
-            const files : Array<{ name: string, path: string, content: string }> = r.files ?? r;
+            const files: Array<{ name: string, path: string, content: string }> = r.files ?? r;
 
             // Metadata is usually the first one
             const metadata = files.find((f) => f.name === "metadata.json")
@@ -412,19 +438,25 @@ type LoaderEnv = {
  *
  * @example
  * ```ts
- * whatsabi.autoload(address, {provider, ...defaultsWithEnv(process.env)})
+ * whatsabi.autoload(address, {provider, ...whatsabi.loaders.defaultsWithEnv(process.env)})
  * ```
  *
  * @example
  * ```ts
  * whatsabi.autoload(address, {
  *     provider,
- *     ...defaultsWithEnv({
+ *     ...whatsabi.loaders.defaultsWithEnv({
  *         SOURCIFY_CHAIN_ID: 42161,
  *         ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
  *         ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
  *     }),
  * })
+ * ```
+ *
+ * @example
+ * Can be useful for stand-alone usage too!
+ * ```ts
+ * const { abiLoader, signatureLookup } = whatsabi.loaders.defaultsWithEnv(env);
  * ```
  */
 export function defaultsWithEnv(env: LoaderEnv): Record<string, ABILoader | SignatureLookup> {

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -64,7 +64,7 @@ export class MultiABILoader implements ABILoader {
         for (const loader of this.loaders) {
             try {
                 const r = await loader.getContract(address);
-                if (r && r.abi.length > 0) return Promise.resolve(r);
+                if (r && r.abi.length > 0) return r;
             } catch (err: any) {
                 if (err.status === 404) continue;
 
@@ -83,7 +83,7 @@ export class MultiABILoader implements ABILoader {
                 const r = await loader.loadABI(address);
 
                 // Return the first non-empty result
-                if (r.length > 0) return Promise.resolve(r);
+                if (r.length > 0) return r;
             } catch (err: any) {
                 throw new MultiABILoaderError("MultiABILoader loadABI error: " + err.message, {
                     context: { loader, address },
@@ -91,7 +91,7 @@ export class MultiABILoader implements ABILoader {
                 });
             }
         }
-        return Promise.resolve([]);
+        return [];
     }
 }
 
@@ -147,9 +147,9 @@ export class EtherscanABILoader implements ABILoader {
                 compilerVersion: result.CompilerVersion,
                 runs: result.Runs,
 
-                getSources: () => {
+                getSources: async () => {
                     try {
-                        return Promise.resolve(this.#toContractSources(result));
+                        return this.#toContractSources(result);
                     } catch (err: any) {
                         throw new EtherscanABILoaderError("EtherscanABILoader getContract getSources error: " + err.message, {
                             context: { url, address },
@@ -236,7 +236,7 @@ export class SourcifyABILoader implements ABILoader {
                 // TODO: Paths will have a sourcify prefix, do we want to strip it to help normalize? It doesn't break anything keeping the prefix, so not sure.
                 // E.g. /contracts/full_match/1/0x1F98431c8aD98523631AE4a59f267346ea31F984/sources/contracts/interfaces/IERC20Minimal.sol
                 // Can use stripPathPrefix helper to do this, but maybe we want something like getSources({ normalize: true })?
-                getSources: () => Promise.resolve(files.map(({ path, content }) => { return { path, content } })),
+                getSources: async () => files.map(({ path, content }) => { return { path, content } }),
 
                 ok: true,
             };
@@ -329,9 +329,9 @@ export class MultiSignatureLookup implements SignatureLookup {
             const r = await lookup.loadFunctions(selector);
 
             // Return the first non-empty result
-            if (r.length > 0) return Promise.resolve(r);
+            if (r.length > 0) return r;
         }
-        return Promise.resolve([]);
+        return [];
     }
 
     async loadEvents(hash: string): Promise<string[]> {
@@ -339,9 +339,9 @@ export class MultiSignatureLookup implements SignatureLookup {
             const r = await lookup.loadEvents(hash);
 
             // Return the first non-empty result
-            if (r.length > 0) return Promise.resolve(r);
+            if (r.length > 0) return r;
         }
-        return Promise.resolve([]);
+        return [];
     }
 }
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,4 +1,4 @@
-import { addressWithChecksum, fetchJSON } from "./utils.js";
+import { fetchJSON } from "./utils.js";
 import * as errors from "./errors.js";
 
 export type ContractResult = {
@@ -250,9 +250,6 @@ export class SourcifyABILoader implements ABILoader {
     }
 
     async getContract(address: string): Promise<ContractResult> {
-        // Sourcify doesn't like it when the address is not checksummed
-        address = addressWithChecksum(address);
-
         {
             // Full match index includes verification settings that matches exactly
             const url = "https://sourcify.dev/server/files/" + this.chainId + "/" + address;
@@ -271,12 +268,9 @@ export class SourcifyABILoader implements ABILoader {
     }
 
     async loadABI(address: string): Promise<any[]> {
-        // Sourcify doesn't like it when the address is not checksummed
-        address = addressWithChecksum(address);
-
         {
             // Full match index includes verification settings that matches exactly
-            const url = "https://repo.sourcify.dev/contracts/full_match/" + this.chainId + "/" + address + "/metadata.json";
+            const url = "https://sourcify.dev/server/repository/contracts/full_match/" + this.chainId + "/" + address + "/metadata.json";
             try {
                 return (await fetchJSON(url)).output.abi;
             } catch (err: any) {
@@ -291,7 +285,7 @@ export class SourcifyABILoader implements ABILoader {
 
         {
             // Partial match index is for verified contracts whose settings didn't match exactly
-            const url = "https://repo.sourcify.dev/contracts/partial_match/" + this.chainId + "/" + address + "/metadata.json";
+            const url = "https://sourcify.dev/server/repository/contracts/partial_match/" + this.chainId + "/" + address + "/metadata.json";
             try {
                 return (await fetchJSON(url)).output.abi;
             } catch (err: any) {


### PR DESCRIPTION
- Added `getSources?: () => Promise<ContractSources>;` to `ContractResult`
- Currently only supported by the Etherscan loader
- `ContractSources` automatically deserializes the encoded source code structure. This will help once we add support for the Sourcify loader which uses a different format (and will require a separate request for each import).
- `ContractResult` is not yet accessible from `AutoloadResult`, so would need to use loaders directly to access it for now. (This will require a bit more plumbing, since autoload uses loadABI rather than loadContract, so we'll need yet another flag to include contract sources.)
- Fixes #111 

Usage:

```typescript
const result = await loader.getContract(address);
const sources = await result.getSources();

for (const s of sources) {
  console.log(s.path, " -> ", s.content.slice(25) + "...");
}
```