### PR TITLE
auto: Add CrossChainLoad support for verified contracts

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'vitest';
 import { whatsabi } from "../index";
 import { autoload } from "../auto";
 
-import { test, online_test } from "./env";
+import { test, online_test, makeProvider } from "./env";
 
 const TIMEOUT = 15000;
 
@@ -12,7 +12,7 @@ test('autoload throws typed error', async () => {
     await expect(autoload("0xf00")).rejects.toThrow(/config is undefined/);
 
     const fakeProvider = {
-        request: () => {},
+        request: () => { },
     }
     await expect(autoload("abc.eth", { provider: fakeProvider })).rejects.toThrow(/Failed to resolve ENS/);
 });
@@ -24,8 +24,8 @@ online_test('autoload selectors', async ({ provider }) => {
         abiLoader: false,
         signatureLookup: false,
     });
-    expect(abi).toContainEqual({"selector": "0x6dbf2fa0", "type": "function"});
-    expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
+    expect(abi).toContainEqual({ "selector": "0x6dbf2fa0", "type": "function" });
+    expect(abi).toContainEqual({ "selector": "0xec0ab6a7", "type": "function" });
 }, TIMEOUT);
 
 online_test('autoload selectors with experimental metadata', async ({ provider }) => {
@@ -36,8 +36,8 @@ online_test('autoload selectors with experimental metadata', async ({ provider }
         signatureLookup: false,
         enableExperimentalMetadata: true,
     });
-    expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function"});
-    expect(abi).toContainEqual({"inputs": [{"type": "bytes", "name": ""}], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function"});
+    expect(abi).toContainEqual({ "inputs": [{ "type": "bytes", "name": "" }], "payable": true, "selector": "0x6dbf2fa0", "stateMutability": "payable", "type": "function" });
+    expect(abi).toContainEqual({ "inputs": [{ "type": "bytes", "name": "" }], "payable": true, "selector": "0xec0ab6a7", "stateMutability": "payable", "type": "function" });
 }, TIMEOUT);
 
 
@@ -57,9 +57,9 @@ online_test('autoload full', async ({ provider, env }) => {
         ]),
         //onProgress: (phase: string, ...args: any[]) => { console.debug("PROGRESS", phase, args); },
     });
-    expect(abi).toContainEqual({"constant": false, "inputs": [{"type": "address", "name": ""}, {"type": "uint256", "name": ""}, {"type": "bytes", "name": ""}], "name": "call", "payable": false, "selector": "0x6dbf2fa0", "sig": "call(address,uint256,bytes)", "type": "function"})
+    expect(abi).toContainEqual({ "constant": false, "inputs": [{ "type": "address", "name": "" }, { "type": "uint256", "name": "" }, { "type": "bytes", "name": "" }], "name": "call", "payable": false, "selector": "0x6dbf2fa0", "sig": "call(address,uint256,bytes)", "type": "function" })
 
-    expect(abi).toContainEqual({"selector": "0xec0ab6a7", "type": "function"});
+    expect(abi).toContainEqual({ "selector": "0xec0ab6a7", "type": "function" });
 }, TIMEOUT);
 
 online_test('autoload non-contract', async ({ provider, env }) => {
@@ -70,3 +70,53 @@ online_test('autoload non-contract', async ({ provider, env }) => {
     });
     expect(abi).toStrictEqual([]);
 });
+
+online_test('autoload crossload', async ({ provider, env }) => {
+    const address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"; // USDT, available on both PulseChain and Mainnet (but only verified on mainnet)
+    const pulseChainProvider = makeProvider("https://pulsechain-rpc.publicnode.com");
+    {
+        // Fails to find verified ABI on pulseChain
+        const result = await autoload(address, {
+            provider: pulseChainProvider,
+            signatureLookup: false,
+            abiLoader: false,
+        });
+        expect(result.isVerified).toBeFalsy();
+        expect(result.abi).not.toContainEqual({
+            "constant": true,
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [ { "name": "", "type": "uint256", }],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+        });
+    }
+    {
+        // Succeeds by cross-loading mainnet
+        const result = await autoload(address, {
+            provider: pulseChainProvider,
+            signatureLookup: false,
+            abiLoader: false,
+            // onProgress: (phase: string, ...args: any[]) => { console.debug("Mainnet PROGRESS", phase, args); },
+            crossChainLoad: {
+                provider,
+                signatureLookup: false,
+                // onProgress: (phase: string, ...args: any[]) => { console.debug("CrossChain PROGRESS", phase, args); },
+                ...whatsabi.loaders.defaultsWithEnv(env),
+            }
+        });
+        expect(result.isVerified).toBeTruthy();
+        expect(result.abi).toContainEqual({
+            "constant": true,
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [ { "name": "", "type": "uint256", }],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+        });
+    }
+});
+
+

--- a/src/__tests__/env.ts
+++ b/src/__tests__/env.ts
@@ -5,7 +5,7 @@ import { createPublicClient, createWalletClient, http } from 'viem';
 import { Web3 } from "web3";
 
 import { withCache } from "../internal/filecache";
-import { CompatibleProvider } from "../providers.js";
+import { CompatibleProvider, Provider } from "../providers.js";
 
 const env = {
     INFURA_API_KEY: process.env.INFURA_API_KEY,
@@ -17,31 +17,42 @@ const env = {
 
 const DEFAULT_PUBLIC_RPC = "https://ethereum-rpc.publicnode.com";
 
-const provider = CompatibleProvider(function() {
-    let rpc_url = env.PROVIDER_RPC_URL;
-    if (env.INFURA_API_KEY) {
-        rpc_url = "https://mainnet.infura.io/v3/" + env.INFURA_API_KEY;
-    }
 
-    if (env.PROVIDER?.startsWith("viem")) {
-        const transport = http(rpc_url ?? DEFAULT_PUBLIC_RPC);
-        if (env.PROVIDER.endsWith("publicClient")) return createPublicClient({ transport });
-        if (env.PROVIDER.endsWith("transport")) return transport({});
-        return createWalletClient({ transport });
-    }
+/**
+ * Make a CompatibleProvider for testing relative to the environment we're testing against.
+ */
+export function makeProvider(rpc_url?: string): Provider {
+    return CompatibleProvider(function() {
+        if (!rpc_url) {
+            if (env.INFURA_API_KEY) {
+                rpc_url = "https://mainnet.infura.io/v3/" + env.INFURA_API_KEY;
+            } else {
+                rpc_url = env.PROVIDER_RPC_URL;
+            }
+        }
 
-    if (env.PROVIDER === "web3") {
-        return new Web3(rpc_url ?? DEFAULT_PUBLIC_RPC);
-    }
+        if (env.PROVIDER?.startsWith("viem")) {
+            const transport = http(rpc_url ?? DEFAULT_PUBLIC_RPC);
+            if (env.PROVIDER.endsWith("publicClient")) return createPublicClient({ transport });
+            if (env.PROVIDER.endsWith("transport")) return transport({});
+            return createWalletClient({ transport });
+        }
 
-    if (!env.PROVIDER || env.PROVIDER === "ethers") {
-        if (env.PROVIDER_RPC_URL) return new ethers.JsonRpcProvider(env.PROVIDER_RPC_URL);
-        if (env.INFURA_API_KEY) return new ethers.InfuraProvider("homestead", env.INFURA_API_KEY);
-        return new ethers.JsonRpcProvider(DEFAULT_PUBLIC_RPC);
-    }
+        if (env.PROVIDER === "web3") {
+            return new Web3(rpc_url ?? DEFAULT_PUBLIC_RPC);
+        }
 
-    throw new Error("Unknown PROVIDER: " + env.PROVIDER);
-}());
+        if (!env.PROVIDER || env.PROVIDER === "ethers") {
+            if (rpc_url) return new ethers.JsonRpcProvider(rpc_url);
+            if (env.INFURA_API_KEY) return new ethers.InfuraProvider("homestead", env.INFURA_API_KEY);
+            return new ethers.JsonRpcProvider(DEFAULT_PUBLIC_RPC);
+        }
+
+        throw new Error("Unknown PROVIDER: " + env.PROVIDER);
+    }());
+}
+
+const provider = makeProvider();
 
 type ItConcurrent = typeof test.skip;
 


### PR DESCRIPTION
Example:

```typescript
 // USDT, available on both PulseChain and Mainnet (but only verified on mainnet)
const address = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
const result = await autoload(address, {
  provider: pulseChainProvider,
  crossChainLoad: {
    mainnnetProvider,
    ...whatsabi.loaders.defaultsWithEnv(env),
  }
});
console.log(result); // {isVerified: true, abi: [...], ...}
```