### PR TITLE
src/loader.ts: Add fallback for contract name in SourcifyABILoader

### DIFF
--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -73,7 +73,7 @@ describe('loaders module', () => {
     const selectors = Object.values(selectorsFromABI(abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
     expect(selectors).toContain(sig);
-    expect(name).toBeFalsy()
+    expect(name).toBe("UniswapV2Router02");
 
     expect(userdoc).toBeDefined();
     expect(devdoc).toBeDefined();

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -255,9 +255,19 @@ export class SourcifyABILoader implements ABILoader {
             // Note: Sometimes metadata.json contains sources, but not always. So we can't rely on just the metadata.json
             const m = JSON.parse(metadata.content);
 
+            // Sourcify includes a title from the Natspec comments
+            let name = m.output.devdoc?.title;
+            if (!name && m.settings.compilationTarget) {
+                // Try to use the compilation target name as a fallback
+                const targetNames = Object.values(m.settings.compilationTarget);
+                if (targetNames.length > 0) {
+                    name = targetNames[0];
+                }
+            }
+
             return {
                 abi: m.output.abi,
-                name: m.output.devdoc?.title ?? null, // Sourcify includes a title from the Natspec comments
+                name: name ?? null,
                 evmVersion: m.settings.evmVersion,
                 compilerVersion: m.compiler.version,
                 runs: m.settings.optimizer.runs,


### PR DESCRIPTION
Resolves #117 

Add fallback in the `SourcifyABILoader` to handle cases where the contract name is missing from the Natspec comments (`devdoc.title`).