### PR TITLE
loaders: Enhance `ContractResult.loaderResult` type

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -397,7 +397,7 @@ export class SourcifyABILoader implements ABILoader {
 
 export class SourcifyABILoaderError extends errors.LoaderError { };
 
-// Contract metadata from Sourcify
+/// Sourcify Contract metadata from API response
 export interface SourcifyContractMetadata {
     compiler: {
         version: string;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -60,7 +60,7 @@ export type ContractResult = {
      *
      * @experimental
      */
-    loaderResult?: EtherscanContractResult | ContractMetadata | any;
+    loaderResult?: EtherscanContractResult | SourcifyContractMetadata | any;
 }
 
 /**
@@ -305,7 +305,7 @@ export class SourcifyABILoader implements ABILoader {
             if (metadata === undefined) throw new SourcifyABILoaderError("metadata.json not found");
 
             // Note: Sometimes metadata.json contains sources, but not always. So we can't rely on just the metadata.json
-            const m = JSON.parse(metadata.content) as ContractMetadata;
+            const m = JSON.parse(metadata.content) as SourcifyContractMetadata;
 
             // Sourcify includes a title from the Natspec comments
             let name = m.output.devdoc?.title;
@@ -397,15 +397,16 @@ export class SourcifyABILoader implements ABILoader {
 
 export class SourcifyABILoaderError extends errors.LoaderError { };
 
-interface ContractMetadata {
+// Contract metadata from Sourcify
+interface SourcifyContractMetadata {
     compiler: {
         version: string;
     };
     language: string;
     output: {
         abi: any[];
-        devdoc: any;
-        userdoc: any;
+        devdoc?: any;
+        userdoc?: any;
     };
     settings: {
         compilationTarget: Record<string, string>;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -255,7 +255,7 @@ export class EtherscanABILoader implements ABILoader {
 
 export class EtherscanABILoaderError extends errors.LoaderError { };
 
-// Etherscan Contract Source API response
+/// Etherscan Contract Source API response
 export type EtherscanContractResult = {
   SourceCode: string;
   ABI: string;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -398,7 +398,7 @@ export class SourcifyABILoader implements ABILoader {
 export class SourcifyABILoaderError extends errors.LoaderError { };
 
 // Contract metadata from Sourcify
-interface SourcifyContractMetadata {
+export interface SourcifyContractMetadata {
     compiler: {
         version: string;
     };


### PR DESCRIPTION
Follow-up PR to #127

**Change overview**
- Introduced `EtherscanContractResult` type
- Introduced `SourcifyContractMetadata` type
- Updated `ContractResult.loaderResult` type