### PR TITLE
src/auto.ts: check if contractResult.abi is not empty

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -242,7 +242,7 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
         try {
             if (config.loadContractResult) {
                 const contractResult = await loader.getContract(address);
-                if (contractResult) {
+                if (contractResult && Array.isArray(contractResult.abi) && contractResult.abi.length > 0) {
                     // We assume that a verified contract ABI contains all of the relevant resolved proxy functions
                     // so we don't need to mess with resolving facets and can return immediately.
                     result.contractResult = contractResult;


### PR DESCRIPTION
This PR updates the autoload function to improve handling of unverified contracts. If a contract's ABI is empty, we now fallback to using the inferred ABI instead of returning empty ABI.

Please see:
- #136

**Note:** The problem only occurs when `loadContractResult: true` is set in `AutoloadConfig`