### PR TITLE
loaders: Avoid exception when Etherscan returns an empty response

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -199,6 +199,11 @@ export class EtherscanABILoader implements ABILoader {
                 throw new Error(r.result);    // This gets wrapped below
             }
 
+            // Status 1 means success, but the result could still be empty
+            if (r.result.length > 0 && r.result[0].ABI === "Contract source code not verified")  {
+                return emptyContractResult;
+            }
+
             const result = r.result[0] as EtherscanContractResult;
             return {
                 abi: JSON.parse(result.ABI),


### PR DESCRIPTION
Hi @shazow,

I made a small adjustment. This fix is necessary because, in MultiABILoader, when an exception occurs in the Etherscan loader, it does not fall back to the Sourcify loader (when they are set in MultiABILoader in this order). I would appreciate it if you could kindly review it.

Example response from Etherscan API:
![image](https://github.com/user-attachments/assets/fec3c501-606c-4c7d-a5cb-70e130a5e6d7)
