### PR TITLE
The error status is inside err.cause

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -121,7 +121,7 @@ export class MultiABILoader implements ABILoader {
                     return r;
                 }
             } catch (err: any) {
-                if (err.status === 404) continue;
+                if (err.cause?.status === 404) continue;
 
                 throw new MultiABILoaderError("MultiABILoader getContract error: " + err.message, {
                     context: { loader, address },
@@ -143,6 +143,8 @@ export class MultiABILoader implements ABILoader {
                     return r;
                 }
             } catch (err: any) {
+                if (err.cause?.status === 404) continue;
+
                 throw new MultiABILoaderError("MultiABILoader loadABI error: " + err.message, {
                     context: { loader, address },
                     cause: err,


### PR DESCRIPTION
This one's not quite as clean, since it's not guaranteed that a failing loader actually has a status of 404.  It appears to be true for the existing loaders though, so it correctly catches the error.

A cleaner way to do this might be to have the loaders themselves decide when to fail quietly and when to throw an error.  If it's simply not finding the ABI, fail quietly instead.

https://github.com/shazow/whatsabi/issues/159