### PR TITLE
tests: Improve loader tests, add no-result checks

### DIFF
--- a/src/__tests__/env.ts
+++ b/src/__tests__/env.ts
@@ -62,6 +62,8 @@ type TestWithContext = (
     timeout?: number
 ) => void;
 
+// TODO: Switch to using test.extend? https://vitest.dev/api/#test-extend
+
 function testerWithContext(tester: ItConcurrent, context: any): TestWithContext {
     return (name, fn, timeout) => tester(name, () => fn(context), timeout);
 }

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -86,12 +86,6 @@ describe('loaders: ABILoader', () => {
     expect(result.loaderResult?.output?.devdoc).toBeDefined();
   })
 
-  online_test('SourcifyABILoader_getContract_missing', async () => {
-    const loader = new SourcifyABILoader();
-    const r = await loader.getContract("0x0000000000000000000000000000000000000000");
-    expect(r.ok).toBeFalsy();
-  })
-
   online_test('SourcifyABILoader_getContract_UniswapV3Factory', async () => {
     const loader = new SourcifyABILoader();
     const { abi, name } = await loader.getContract("0x1F98431c8aD98523631AE4a59f267346ea31F984");
@@ -145,14 +139,6 @@ describe('loaders: ABILoader', () => {
 
     const sources = result.getSources && await result.getSources();
     expect(sources && sources[0].content).toContain("pragma solidity");
-  })
-
-  online_test('BlockscoutABILoader_getContract_missing', async ({ env }) => {
-    const loader = new BlockscoutABILoader({
-      apiKey: env["BLOCKSCOUT_API_KEY"],
-    });
-    const r = await loader.getContract("0x0000000000000000000000000000000000000000");
-    expect(r.ok).toBeFalsy();
   })
 
   online_test('BlockscoutABILoader_getContract_UniswapV3Factory', async ({ env }) => {
@@ -253,7 +239,7 @@ describe_cached("loaders: ABILoader suite", async ({ env }) => {
   const uniswapV2Router = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d";
   makeTest(new SourcifyABILoader(), uniswapV2Router);
   makeTest(new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }), uniswapV2Router);
-  makeTest(new BlockscoutABILoader(), uniswapV2Router);
+  makeTest(new BlockscoutABILoader({ apiKey: env["BLOCKSCOUT_API_KEY"] }), uniswapV2Router);
 });
 
 

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -227,20 +227,33 @@ describe('loaders: ABILoader', () => {
   }, SLOW_ETHERSCAN_TIMEOUT);
 });
 
-describe_cached("loaders: ABILoader check no result", async ({ env }) => {
-  function makeTest(loader: ABILoader) {
-    online_test(loader.name, async () => {
-      // Addess we know won't have a verified ABI 
-      const address = "0x0000000000000000000000000000000000000001";
-      const r = await loader.getContract(address);
+describe_cached("loaders: ABILoader suite", async ({ env }) => {
+  // Addess we know won't have a verified ABI 
+  const knownUnverified = "0x0000000000000000000000000000000000000001";
+
+  function makeTest(loader: ABILoader, knownVerified: string) {
+    online_test(`${loader.name} unverified getContract`, async () => {
+      const r = await loader.getContract(knownUnverified);
       expect(r.ok).toBeFalsy();
       expect(r.abi).toStrictEqual([]);
     });
+
+    online_test(`${loader.name} unverified loadABI`, async () => {
+      const r = await loader.loadABI(knownUnverified);
+      expect(r).toStrictEqual([]);
+    });
+
+    online_test(`${loader.name} verified getContract`, async () => {
+      const r = await loader.getContract(knownVerified);
+      expect(r.ok).toBeTruthy();
+      expect(r.abi).not.toStrictEqual([]);
+    });
   }
 
-  makeTest(new SourcifyABILoader());
-  makeTest(new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }));
-  makeTest(new BlockscoutABILoader());
+  const uniswapV2Router = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d";
+  makeTest(new SourcifyABILoader(), uniswapV2Router);
+  makeTest(new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }), uniswapV2Router);
+  makeTest(new BlockscoutABILoader(), uniswapV2Router);
 });
 
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -525,7 +525,7 @@ export class BlockscoutABILoader implements ABILoader {
             const r = await fetch(url);
             const result = (await r.json()) as BlockscoutContractResult;
             if (!result.abi) {
-                throw new Error("ABI is not found");
+                return [];
             }
             return result.abi;
         } catch (err: any) {


### PR DESCRIPTION
Preparing to add more loaders.
- Add test suite for loaders in general
- loaders.BlockscoutABILoader.loadABI updated to return [] on empty instead of throwing an error.