### PR TITLE
autoload: Add `hasCode` property to `AutoloadResult` type

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -17,6 +17,15 @@ test('autoload throws typed error', async () => {
     await expect(autoload("abc.eth", { provider: fakeProvider })).rejects.toThrow(/Failed to resolve ENS/);
 });
 
+test('autoload sets hasCode to false if code is empty', async () => {
+    const fakeProvider = (code: string) => ({
+      request: () => code,
+    });
+    const address = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+    await expect(autoload(address, { provider: fakeProvider("0x") })).resolves.toMatchObject({ hasCode: false });
+    await expect(autoload(address, { provider: fakeProvider("0x1234") })).resolves.toMatchObject({ hasCode: true });
+});
+
 online_test('autoload selectors', async ({ provider }) => {
     const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
     const { abi } = await autoload(address, {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -50,6 +50,9 @@ export type AutoloadResult = {
      * @experimental
      */
     isFactory?: boolean;
+
+    /** Set to true if the address has deployed code */
+    hasCode: boolean;
 }
 
 
@@ -157,6 +160,7 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
         address,
         abi: [],
         proxies: [],
+        hasCode: false,
     };
 
     let abiLoader = config.abiLoader;
@@ -191,7 +195,8 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
             },
         );
     }
-    if (!bytecode) return result; // Must be an EOA
+    if (!bytecode || bytecode === "0x") return result; // Must be an EOA
+    result.hasCode = true;
 
     const program = disasm(bytecode);
 


### PR DESCRIPTION
Fixes #165

- Added the `hasCode` property to the `AutoloadResult` type. It is set to `false` when no contract is deployed at the specified address.