### PR TITLE
proxies: Skip followProxies if contract is complex enough to be a destination itself

### DIFF
--- a/examples/autoload.ts
+++ b/examples/autoload.ts
@@ -34,7 +34,7 @@ async function main() {
         process.exit(1);
     }
 
-    let extraConfig : AutoloadConfig = whatsabi.loaders.defaultsWithEnv(env);
+    let extraConfig : object = whatsabi.loaders.defaultsWithEnv(env);
     if (env.SKIP_LOOKUPS) {
         console.debug("Skipping lookups, only using bytecode");
         extraConfig = {
@@ -59,7 +59,12 @@ async function main() {
         const detectedInterfaces = whatsabi.interfaces.abiToInterfaces(abi);
         if (detectedInterfaces.length) console.log("detected interfaces:", detectedInterfaces);
 
-        if (!r.followProxies) break;
+        if (!r.followProxies) {
+            if (r.proxies.length) {
+                console.log("proxies detected but not following:", r.proxies);
+            }
+            break;
+        }
 
         console.log("following proxies...");
         r = await r.followProxies();

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -154,6 +154,7 @@ export class Program {
     proxySlots: Array<string>; // PUSH32 found that match known proxy slots
     proxies: Array<ProxyResolver>;
     isFactory: boolean; // CREATE or CREATE2 detected
+    sstoreCount: number; // Number of SSTORE instructions detected, used to determine if this may be a destination contract (vs a proxy)
 
     init?: Program; // Program embedded as init code
 
@@ -165,6 +166,7 @@ export class Program {
         this.proxySlots = [];
         this.proxies = [];
         this.isFactory = false;
+        this.sstoreCount = 0;
         this.init = init;
     }
 }
@@ -368,6 +370,8 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
                 // CREATE/CREATE2 are part of interestingOpCodes so we can leverage this short circuit
                 if (inst === opcodes.CREATE || inst === opcodes.CREATE2) {
                     p.isFactory = true;
+                } else if (inst === opcodes.SSTORE) {
+                    p.sstoreCount += 1;
                 }
             }
         }


### PR DESCRIPTION
Fixes #173 

Summary: Sometimes a contract contains proxy-like code, but it's actually a destination contract itself.

This PR adds a heuristic where we skip the `AutoloadResult.followProxies` when the bytecode contains more than 4 SSTORE instructions.

I sampled a bunch of proxies, and most upgradeable proxies have 1-2 sstores, and typical contracts have dozens of sstores. 3 felt a little tight, but 5 feels pretty safe. Can tweak this later.