### PR TITLE
add test against the selector, change the diamond storage

### DIFF
--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -282,6 +282,12 @@ describe('comprehensive proxy detection', () => {
         expect(program.proxies.length).toEqual(1);
         const resolver = program.proxies[0];
         expect(resolver.name).toEqual("DiamondProxy");
+
+        const selector = "0x736eac0b";
+        const got = await resolver.resolve(provider, address, selector);
+    
+        expect(got).not.toEqual("0x0000000000000000000000000000000000000000");
+    
     });
 
 });

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -336,7 +336,7 @@ export const slots : Record<string, string> = {
     // Diamond Proxy, as used by ZkSync Era contract
     // https://etherscan.io/address/0x32400084c286cf3e17e7b677ea9583e60a000324#code
     // keccak256("diamond.standard.diamond.storage") - 1;
-    DIAMOND_STORAGE: "0xc8fcad8db84d3cc18b4c41d551ea0ee66dd599cde068d998e57d5e09332c131b",
+    DIAMOND_STORAGE: "0xc8fcad8db84d3cc18b4c41d551ea0ee66dd599cde068d998e57d5e09332c131c",
 
     // EIP-1167 minimal proxy standard
     // Parsed in disasm


### PR DESCRIPTION
for 0.22.0 it seems will still fail the abi resolving due to incorrect default diamond storage. also added the simple test case for resolving the abi for LiFi case. 