### PR TITLE
Upgrade to etherscan v2

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -168,7 +168,7 @@ export class EtherscanABILoader implements ABILoader {
     constructor(config?: { apiKey?: string, baseURL?: string }) {
         if (config === undefined) config = {};
         this.apiKey = config.apiKey;
-        this.baseURL = config.baseURL || "https://api.etherscan.io/api";
+        this.baseURL = config.baseURL || "https://api.etherscan.io/api/v2";
     }
 
 


### PR DESCRIPTION
Etherscan v1 apis have been deprecated causing errors like below so I upgraded the base url to v2. 

```
MultiABILoader loadABI error: EtherscanABILoader loadABI error: Max calls per sec rate limit reached (2/sec). Please switch to API V2, for more info https://docs.etherscan.io/etherscan-v2/v2-quickstart
```