### PR TITLE
loaders: Use EtherscanV2ABILoader, add env.CHAIN_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ let result = await whatsabi.autoload(address, {
 
   // There is a handy helper for adding the default loaders but with your own settings
   ... whatsabi.loaders.defaultsWithEnv({
-    SOURCIFY_CHAIN_ID: 42161,
-    ETHERSCAN_BASE_URL: "https://api.etherscan.io/v2/api",
+    CHAIN_ID: 42161,
     ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
   }),
 

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -58,7 +58,7 @@ online_test('autoload full', async ({ provider, env }) => {
         // ...whatsabi.loaders.defaultsWithEnv(env),
         abiLoader: new whatsabi.loaders.MultiABILoader([
             new whatsabi.loaders.SourcifyABILoader(),
-            new whatsabi.loaders.EtherscanABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
+            new whatsabi.loaders.EtherscanV2ABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
         ]),
         signatureLookup: new whatsabi.loaders.MultiSignatureLookup([
             new whatsabi.loaders.OpenChainSignatureLookup(),
@@ -106,9 +106,9 @@ online_test('autoload loadContractResult verified etherscan', async ({ provider,
         provider: provider,
         loadContractResult: true,
         followProxies: false,
-        abiLoader: new whatsabi.loaders.EtherscanABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
+        abiLoader: new whatsabi.loaders.EtherscanV2ABILoader({ apiKey: env.ETHERSCAN_API_KEY }),
     });
-    expect(result.abiLoadedFrom?.name).toBe("EtherscanABILoader");
+    expect(result.abiLoadedFrom?.name).toBe("EtherscanV2ABILoader");
     expect(result.contractResult?.ok).toBeTruthy();
     expect(result.contractResult?.name).toBe("TransparentUpgradeableProxy");
     expect(result.contractResult?.compilerVersion).toBe("v0.8.15+commit.e14f2714");

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -65,8 +65,7 @@ online_test('README autoload', async ({ provider }) => {
 
             // There is a handy helper for adding the default loaders but with your own settings
             ...whatsabi.loaders.defaultsWithEnv({
-                SOURCIFY_CHAIN_ID: 42161,
-                ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
+                CHAIN_ID: 42161,
                 //ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
             }),
 

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -5,7 +5,7 @@ import {
   defaultSignatureLookup,
 
   SourcifyABILoader,
-  EtherscanABILoader,
+  EtherscanV2ABILoader,
   EtherscanV2ABILoader,
   BlockscoutABILoader,
   AnyABILoader,
@@ -45,8 +45,8 @@ describe('loaders: ABILoader', () => {
     expect(selectors).toContain(sig);
   })
 
-  online_test('EtherscanABILoader', async ({ env }) => {
-    const loader = new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
+  online_test('EtherscanV2ABILoader', async ({ env }) => {
+    const loader = new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
     const abi = await loader.loadABI("0x7a250d5630b4cf539739df2c5dacb4c659f2488d");
     const selectors = Object.values(selectorsFromABI(abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
@@ -68,7 +68,7 @@ describe('loaders: ABILoader', () => {
     const address = "0xa9a57f7d2A54C1E172a7dC546fEE6e03afdD28E2";
     const loader = new MultiABILoader([
       new SourcifyABILoader(),
-      new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
+      new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     ]);
     const abi = await loader.loadABI(address);
     const sig = "getMagistrate()";
@@ -97,8 +97,8 @@ describe('loaders: ABILoader', () => {
     expect(name).toEqual("Canonical Uniswap V3 factory");
   })
 
-  online_test('EtherscanABILoader_getContract', async ({ env }) => {
-    const loader = new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
+  online_test('EtherscanV2ABILoader_getContract', async ({ env }) => {
+    const loader = new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
     const result = await loader.getContract("0x7a250d5630b4cf539739df2c5dacb4c659f2488d");
     const selectors = Object.values(selectorsFromABI(result.abi));
     const sig = "swapExactETHForTokens(uint256,address[],address,uint256)";
@@ -109,8 +109,8 @@ describe('loaders: ABILoader', () => {
 
   }, SLOW_ETHERSCAN_TIMEOUT)
 
-  online_test('EtherscanABILoader_getContract_UniswapV3Factory', async ({ env }) => {
-    const loader = new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
+  online_test('EtherscanV2ABILoader_getContract_UniswapV3Factory', async ({ env }) => {
+    const loader = new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
     const { abi, name } = await loader.getContract("0x1F98431c8aD98523631AE4a59f267346ea31F984");
     const selectors = Object.values(selectorsFromABI(abi));
     const sig = "owner()";
@@ -118,8 +118,8 @@ describe('loaders: ABILoader', () => {
     expect(name).toEqual("UniswapV3Factory");
   }, SLOW_ETHERSCAN_TIMEOUT)
 
-  online_test('EtherscanABILoader_getContract_CompoundUSDCProxy', async ({ env }) => {
-    const loader = new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
+  online_test('EtherscanV2ABILoader_getContract_CompoundUSDCProxy', async ({ env }) => {
+    const loader = new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] });
     const result = await loader.getContract("0xc3d688b66703497daa19211eedff47f25384cdc3");
     expect(result.name).toEqual("TransparentUpgradeableProxy");
     expect(result.loaderResult?.Proxy).toBeTruthy();
@@ -159,21 +159,21 @@ describe('loaders: ABILoader', () => {
     const address = "0xa9a57f7d2A54C1E172a7dC546fEE6e03afdD28E2";
     const loader = new MultiABILoader([
       new SourcifyABILoader(),
-      new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
+      new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     ]);
     const result = await loader.getContract(address);
     const sig = "getMagistrate()";
     const selectors = Object.values(selectorsFromABI(result.abi));
     expect(selectors).toContain(sig);
     expect(result.name).toEqual("KetherSortition");
-    expect(result.loader?.name).toStrictEqual(EtherscanABILoader.name);
+    expect(result.loader?.name).toStrictEqual(EtherscanV2ABILoader.name);
   }, SLOW_ETHERSCAN_TIMEOUT);
 
   online_test('MultiABILoader_getContract_UniswapV3Factory', async ({ env }) => {
     const address = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
     const loader = new MultiABILoader([
       new SourcifyABILoader(),
-      new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
+      new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     ]);
     const { abi, name } = await loader.getContract(address);
     const sig = "owner()";
@@ -200,7 +200,7 @@ describe('loaders: ABILoader', () => {
   online_test('MultiABILoader_EtherscanOnly_getContract_UniswapV3Factory', async ({ env }) => {
     const address = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
     const loader = new MultiABILoader([
-      new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
+      new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     ]);
     const res = await loader.getContract(address);
     const sig = "owner()";
@@ -242,7 +242,6 @@ describe_cached("loaders: ABILoader suite", async ({ env }) => {
 
   const loaders = [
     new SourcifyABILoader(),
-    new EtherscanABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
     new BlockscoutABILoader({ apiKey: env["BLOCKSCOUT_API_KEY"] }),
     new AnyABILoader(),

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -6,7 +6,6 @@ import {
 
   SourcifyABILoader,
   EtherscanV2ABILoader,
-  EtherscanV2ABILoader,
   BlockscoutABILoader,
   AnyABILoader,
   MultiABILoader,

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -154,21 +154,6 @@ describe('loaders: ABILoader', () => {
     expect(name).toEqual("UniswapV3Factory");
   })
 
-  online_test('MultiABILoader_getContract', async ({ env }) => {
-    // A contract that is verified on etherscan but not sourcify
-    const address = "0xa9a57f7d2A54C1E172a7dC546fEE6e03afdD28E2";
-    const loader = new MultiABILoader([
-      new SourcifyABILoader(),
-      new EtherscanV2ABILoader({ apiKey: env["ETHERSCAN_API_KEY"] }),
-    ]);
-    const result = await loader.getContract(address);
-    const sig = "getMagistrate()";
-    const selectors = Object.values(selectorsFromABI(result.abi));
-    expect(selectors).toContain(sig);
-    expect(result.name).toEqual("KetherSortition");
-    expect(result.loader?.name).toStrictEqual(EtherscanV2ABILoader.name);
-  }, SLOW_ETHERSCAN_TIMEOUT);
-
   online_test('MultiABILoader_getContract_UniswapV3Factory', async ({ env }) => {
     const address = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
     const loader = new MultiABILoader([

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -158,7 +158,10 @@ export class MultiABILoader implements ABILoader {
 export class MultiABILoaderError extends errors.LoaderError { };
 
 
-/** Etherscan v1 API loader */
+/**
+  * Etherscan v1 API loader
+  * @deprecated v1 API is deprecated, use EtherscanV2ABILoader instead. This class may change to default to v2 in the future.
+  */
 export class EtherscanABILoader implements ABILoader {
     readonly name: string = "EtherscanABILoader";
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -201,7 +201,7 @@ export class EtherscanABILoader implements ABILoader {
             action: "getsourcecode",
             address: address,
             ...(this.apiKey && { apikey: this.apiKey }),
-          };
+        };
 
         // Using .set() to overwrite any default values that may be present in baseURL
         Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
@@ -214,7 +214,7 @@ export class EtherscanABILoader implements ABILoader {
             }
 
             // Status 1 means success, but the result could still be empty
-            if (r.result.length > 0 && r.result[0].ABI === "Contract source code not verified")  {
+            if (r.result.length > 0 && r.result[0].ABI === "Contract source code not verified") {
                 return emptyContractResult;
             }
 
@@ -256,7 +256,7 @@ export class EtherscanABILoader implements ABILoader {
             action: "getabi",
             address: address,
             ...(this.apiKey && { apikey: this.apiKey }),
-          };
+        };
 
         // Using .set() to overwrite any default values that may be present in baseURL
         Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
@@ -284,19 +284,19 @@ export class EtherscanABILoaderError extends errors.LoaderError { };
 
 /// Etherscan Contract Source API response
 export type EtherscanContractResult = {
-  SourceCode: string;
-  ABI: string;
-  ContractName: string;
-  CompilerVersion: string;
-  OptimizationUsed: number;
-  Runs: number;
-  ConstructorArguments: string;
-  EVMVersion: string;
-  Library: string;
-  LicenseType: string;
-  Proxy: "1" | "0";
-  Implementation: string;
-  SwarmSource: string;
+    SourceCode: string;
+    ABI: string;
+    ContractName: string;
+    CompilerVersion: string;
+    OptimizationUsed: number;
+    Runs: number;
+    ConstructorArguments: string;
+    EVMVersion: string;
+    Library: string;
+    LicenseType: string;
+    Proxy: "1" | "0";
+    Implementation: string;
+    SwarmSource: string;
 }
 
 
@@ -525,7 +525,7 @@ export class BlockscoutABILoader implements ABILoader {
                     } catch (err: any) {
                         throw new BlockscoutABILoaderError(
                             "BlockscoutABILoader getContract getSources error: " +
-                                err.message,
+                            err.message,
                             {
                                 context: { url, address },
                                 cause: err,
@@ -572,7 +572,7 @@ export class BlockscoutABILoader implements ABILoader {
     }
 }
 
-export class BlockscoutABILoaderError extends errors.LoaderError {}
+export class BlockscoutABILoaderError extends errors.LoaderError { }
 
 /// Blockscout Contract Source API response
 export type BlockscoutContractResult = {
@@ -795,9 +795,10 @@ export const defaultABILoader: ABILoader = new MultiABILoader([new SourcifyABILo
 export const defaultSignatureLookup: SignatureLookup = new MultiSignatureLookup([new OpenChainSignatureLookup(), new FourByteSignatureLookup()]);
 
 type LoaderEnv = {
+    CHAIN_ID?: string | number,
+    SOURCIFY_CHAIN_ID?: string | number,
     ETHERSCAN_API_KEY: string,
     ETHERSCAN_CHAIN_ID?: string | number,
-    SOURCIFY_CHAIN_ID?: string | number,
 }
 
 /**
@@ -813,6 +814,19 @@ type LoaderEnv = {
  * whatsabi.autoload(address, {
  *     provider,
  *     ...whatsabi.loaders.defaultsWithEnv({
+ *         // Use this CHAIN_ID for all loaders that support specifying a chain
+ *         CHAIN_ID: 8453,
+ *         ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
+ *     }),
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * whatsabi.autoload(address, {
+ *     provider,
+ *     ...whatsabi.loaders.defaultsWithEnv({
+ *         // Override specific chain IDs per-loader
  *         SOURCIFY_CHAIN_ID: 42161,
  *         ETHERSCAN_CHAIN_ID: 8453,
  *         ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
@@ -828,21 +842,18 @@ type LoaderEnv = {
  */
 export function defaultsWithEnv(env: LoaderEnv): Record<string, ABILoader | SignatureLookup> {
     return {
-      abiLoader: new MultiABILoader([
-        new SourcifyABILoader({
-          chainId:
-            (env.SOURCIFY_CHAIN_ID && Number(env.SOURCIFY_CHAIN_ID)) || undefined,
-        }),
-        new EtherscanV2ABILoader({
-          apiKey: env.ETHERSCAN_API_KEY,
-          chainId:
-            (env.ETHERSCAN_CHAIN_ID && Number(env.ETHERSCAN_CHAIN_ID)) ||
-            undefined,
-        }),
-      ]),
-      signatureLookup: new MultiSignatureLookup([
-        new OpenChainSignatureLookup(),
-        new FourByteSignatureLookup(),
-      ]),
+        abiLoader: new MultiABILoader([
+            new SourcifyABILoader({
+                chainId: Number(env.SOURCIFY_CHAIN_ID ?? env.CHAIN_ID) || undefined,
+            }),
+            new EtherscanV2ABILoader({
+                apiKey: env.ETHERSCAN_API_KEY,
+                chainId: Number(env.ETHERSCAN_CHAIN_ID ?? env.CHAIN_ID) || undefined,
+            }),
+        ]),
+        signatureLookup: new MultiSignatureLookup([
+            new OpenChainSignatureLookup(),
+            new FourByteSignatureLookup(),
+        ]),
     };
-  }  
+}  


### PR DESCRIPTION
We use Etherscan V2 by default, no longer need a separate base URL for each non-mainnet chain.

```diff
             ...whatsabi.loaders.defaultsWithEnv({
-                SOURCIFY_CHAIN_ID: 42161,
-                ETHERSCAN_BASE_URL: "https://api.arbiscan.io/api",
+                CHAIN_ID: 42161,
                 ETHERSCAN_API_KEY: "MYSECRETAPIKEY",
             }),
```