### PR TITLE
loaders: MultiABILoader keeps walking the chain when a loader fails

### DIFF
--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -9,6 +9,7 @@ import {
   BlockscoutABILoader,
   AnyABILoader,
   MultiABILoader,
+  MultiABILoaderError,
 
   OpenChainSignatureLookup,
   SamczunSignatureLookup,
@@ -282,5 +283,80 @@ describe('loaders: helpers', () => {
     expect(
       SourcifyABILoader.stripPathPrefix("/contracts/full_match/1/0x1F98431c8aD98523631AE4a59f267346ea31F984/metadata.json")
     ).toEqual("metadata.json");
+  });
+});
+
+
+describe('loaders: MultiABILoader with degraded loaders', () => {
+  const address = "0xc0Da02939E1441F497fd74F78cE7Decb17B66529";
+  const verifiedABI = [
+    { type: "event", name: "NewImplementation" },
+    { type: "function", name: "implementation" },
+  ];
+
+  const failingLoader = (status?: number): ABILoader => ({
+    name: "FailingLoader",
+    getContract: async () => {
+      throw Object.assign(new Error(`upstream failure${status ? " " + status : ""}`), status ? { cause: { status } } : {});
+    },
+    loadABI: async () => {
+      throw Object.assign(new Error(`upstream failure${status ? " " + status : ""}`), status ? { cause: { status } } : {});
+    },
+  });
+
+  const okLoader: ABILoader = {
+    name: "OkLoader",
+    getContract: async () => ({ abi: verifiedABI, name: "Verified", ok: true }),
+    loadABI: async () => verifiedABI,
+  };
+
+  test('continues to the next loader when one fails', async () => {
+    const loader = new MultiABILoader([failingLoader(503), okLoader]);
+
+    expect(await loader.loadABI(address)).toEqual(verifiedABI);
+
+    const r = await loader.getContract(address);
+    expect(r.abi).toEqual(verifiedABI);
+    expect(r.name).toEqual("Verified");
+    expect(r.ok).toBeTruthy();
+  });
+
+  test('still treats a 404 as an ordinary miss', async () => {
+    const loader = new MultiABILoader([failingLoader(404), okLoader]);
+
+    expect(await loader.loadABI(address)).toEqual(verifiedABI);
+    expect((await loader.getContract(address)).name).toEqual("Verified");
+  });
+
+  test('throws an aggregate error when no loader can answer', async () => {
+    const loader = new MultiABILoader([failingLoader(503), failingLoader()]);
+
+    await expect(loader.loadABI(address)).rejects.toThrow(MultiABILoaderError);
+    const err: MultiABILoaderError = await loader.getContract(address).then(
+      () => { throw new Error("expected getContract to reject") },
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(MultiABILoaderError);
+    expect(err.context?.failures).toHaveLength(2);
+    // Kept for compatibility with the pre-aggregate error shape.
+    expect(err.context?.loader?.name).toEqual("FailingLoader");
+  });
+
+  test('throws rather than reporting unverified when a loader was unreachable', async () => {
+    // A clean miss from one loader cannot prove "unverified" while another
+    // loader was down: the contract might only be indexed by the broken one.
+    const loader = new MultiABILoader([failingLoader(503), failingLoader(404)]);
+
+    await expect(loader.loadABI(address)).rejects.toThrow(MultiABILoaderError);
+    await expect(loader.getContract(address)).rejects.toThrow(MultiABILoaderError);
+  });
+
+  test('returns the empty result when every loader misses', async () => {
+    const loader = new MultiABILoader([failingLoader(404), failingLoader(404)]);
+
+    expect(await loader.loadABI(address)).toEqual([]);
+    const r = await loader.getContract(address);
+    expect(r.abi).toEqual([]);
+    expect(r.ok).toBeFalsy();
   });
 });

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -113,6 +113,7 @@ export class MultiABILoader implements ABILoader {
     }
 
     async getContract(address: string): Promise<ContractResult> {
+        const failures: { loader: ABILoader, error: any }[] = [];
         for (const loader of this.loaders) {
             try {
                 const r = await loader.getContract(address);
@@ -121,18 +122,28 @@ export class MultiABILoader implements ABILoader {
                     return r;
                 }
             } catch (err: any) {
+                // A 404 is an ordinary miss (contract not indexed by this
+                // loader); anything else is a loader failure. Keep walking the
+                // chain either way, so one degraded loader can't mask a
+                // healthy loader behind it.
                 if (err.cause?.status === 404) continue;
-
-                throw new MultiABILoaderError("MultiABILoader getContract error: " + err.message, {
-                    context: { loader, address },
-                    cause: err,
-                });
+                failures.push({ loader, error: err });
             }
+        }
+        if (failures.length > 0) {
+            // No loader produced a result and at least one failed, so we
+            // can't distinguish "unverified" from "unavailable". Surface the
+            // failures rather than returning a false miss.
+            throw new MultiABILoaderError("MultiABILoader getContract errors: " + failures.map(f => f.loader.name + ": " + f.error.message).join("; "), {
+                context: { failures, address, loader: failures[0].loader },
+                cause: failures[0].error,
+            });
         }
         return emptyContractResult;
     }
 
     async loadABI(address: string): Promise<any[]> {
+        const failures: { loader: ABILoader, error: any }[] = [];
         for (const loader of this.loaders) {
             try {
                 const r = await loader.loadABI(address);
@@ -143,13 +154,16 @@ export class MultiABILoader implements ABILoader {
                     return r;
                 }
             } catch (err: any) {
+                // Same walk semantics as getContract above.
                 if (err.cause?.status === 404) continue;
-
-                throw new MultiABILoaderError("MultiABILoader loadABI error: " + err.message, {
-                    context: { loader, address },
-                    cause: err,
-                });
+                failures.push({ loader, error: err });
             }
+        }
+        if (failures.length > 0) {
+            throw new MultiABILoaderError("MultiABILoader loadABI errors: " + failures.map(f => f.loader.name + ": " + f.error.message).join("; "), {
+                context: { failures, address, loader: failures[0].loader },
+                cause: failures[0].error,
+            });
         }
         return [];
     }


### PR DESCRIPTION
Today, July 7, 2026, Sourcify's files API returned 503 for several hours (while `/server/health` stayed 200), and with `SourcifyABILoader` first in our chain, no lookup ever reached the healthy fallback loaders.  Under `autoload` with an `onError` handler, the failure was swallowed and every contract silently degraded to a bytecode-decompiled ABI (no events, no constructor).  For us that meant event-derived data quietly disappeared downstream, which was much harder to notice than an error would have been.

## Problem

`MultiABILoader` treats any non-404 loader error as fatal: the walk aborts and throws, so a degraded loader early in the chain masks every healthy loader behind it.

## Change

Scoped to `MultiABILoader.getContract` and `MultiABILoader.loadABI`; individual loaders and the `ABILoader` interface are untouched.  Both methods now collect loader failures and keep walking:

- The first loader that successfully returns a result still wins.  A failing loader is now recorded and skipped instead of aborting the walk, so loaders behind it still get their turn.
- A 404 is still an ordinary miss, as before.
- If **no** loader produces a result and at least one failed with a non-404, throw a single aggregate `MultiABILoaderError` naming every failed loader.  Rationale: a clean miss can't prove "unverified" while another loader was unreachable, and returning the empty result there would make a bad API key indistinguishable from "every contract is unverified".
- All loaders missing cleanly still returns the empty result, as before.

`err.context.loader` is preserved (first failed loader) alongside a new `err.context.failures` array, so existing consumers of the error shape keep working.  One subtle timing change: a failure followed by a clean miss now throws at the end of the walk instead of at the failing loader.

Happy to adjust the all-failed case to return the empty result instead of throwing if you'd rather `MultiABILoader` never throw; the tests make either contract easy to pin down.