### PR TITLE
loaders: BlockscoutABILoader accepts chainId via the multichain gateway

### DIFF
--- a/src/__tests__/env.ts
+++ b/src/__tests__/env.ts
@@ -10,6 +10,7 @@ import { CompatibleProvider, Provider } from "../providers.js";
 const env = {
     INFURA_API_KEY: process.env.INFURA_API_KEY,
     ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
+    BLOCKSCOUT_API_KEY: process.env.BLOCKSCOUT_API_KEY,
 
     PROVIDER: process.env.PROVIDER,
     PROVIDER_RPC_URL: process.env.PROVIDER_RPC_URL,

--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -62,6 +62,16 @@ describe('loaders: ABILoader', () => {
     expect(selectors).toContain(sig);
   })
 
+  online_test('BlockscoutABILoader_chainId', async ({ env }) => {
+    const loader = new BlockscoutABILoader({
+      apiKey: env["BLOCKSCOUT_API_KEY"],
+      chainId: 8453,
+    });
+    const abi = await loader.loadABI("0x4200000000000000000000000000000000000006"); // WETH9 predeploy on Base
+    const selectors = Object.values(selectorsFromABI(abi));
+    expect(selectors).toContain("deposit()");
+  })
+
   online_test('MultiABILoader', async ({ env }) => {
     // A contract that is verified on etherscan but not sourcify
     const address = "0xa9a57f7d2A54C1E172a7dC546fEE6e03afdD28E2";
@@ -282,5 +292,20 @@ describe('loaders: helpers', () => {
     expect(
       SourcifyABILoader.stripPathPrefix("/contracts/full_match/1/0x1F98431c8aD98523631AE4a59f267346ea31F984/metadata.json")
     ).toEqual("metadata.json");
+  });
+
+  test('BlockscoutABILoader baseURL from chainId', () => {
+    // chainId routes through the multichain gateway, like EtherscanV2ABILoader
+    expect(
+      new BlockscoutABILoader({ apiKey: "key", chainId: 8453 }).baseURL
+    ).toEqual("https://api.blockscout.com/8453/api");
+
+    // No config keeps the historical default
+    expect(new BlockscoutABILoader().baseURL).toEqual("https://eth.blockscout.com/api");
+
+    // An explicit baseURL wins over chainId
+    expect(
+      new BlockscoutABILoader({ baseURL: "https://base.blockscout.com/api", chainId: 8453 }).baseURL
+    ).toEqual("https://base.blockscout.com/api");
   });
 });

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -466,10 +466,16 @@ export class BlockscoutABILoader implements ABILoader {
     apiKey?: string;
     baseURL: string;
 
-    constructor(config?: { apiKey?: string; baseURL?: string }) {
+    constructor(config?: { apiKey?: string; baseURL?: string; chainId?: number }) {
         if (config === undefined) config = {};
         this.apiKey = config.apiKey;
-        this.baseURL = config.baseURL || "https://eth.blockscout.com/api";
+        // A chainId routes through the multichain gateway, which requires an
+        // apiKey (or an x402 payment); the server enforces this. An explicit
+        // baseURL wins over chainId.
+        this.baseURL = config.baseURL ||
+            (config.chainId !== undefined
+                ? `https://api.blockscout.com/${config.chainId}/api`
+                : "https://eth.blockscout.com/api");
     }
 
     /** Blockscout helper for converting the result arg to a decoded ContractSources. */


### PR DESCRIPTION
`SourcifyABILoader` and `EtherscanV2ABILoader` are chain-aware through a `chainId` config; `BlockscoutABILoader` requires knowing the instance URL upfront.  Blockscout has a multichain gateway (`api.blockscout.com/{chainId}/...`) that serves the same API surface for any chain it indexes, so `chainId` support is a URL template, the same shape as the EtherscanV2 loader.

## Change

- `BlockscoutABILoader` accepts `chainId` and routes through Blockscout's multichain gateway: `https://api.blockscout.com/{chainId}/api`.
- **Existing users see no change.**  With no config, the loader stays on `https://eth.blockscout.com/api`, which allows public reads at standard rate limits, no API key needed.  An explicit `baseURL` (any per-chain instance, e.g. `base.blockscout.com/api`, or a self-hosted one) also behaves exactly as before, public reads included.
- **The new `chainId` path is effectively a with-API-key feature.**  Per-chain instance hosts allow keyless reads, but the multichain gateway requires an `apiKey` (or x402 payment) on every endpoint.  That's enforced server-side, so keyless `chainId` use fails with the gateway's own 402 rather than anything this loader invents.
- Precedence: explicit `baseURL` wins over `chainId`; `baseURL` stays an eagerly-set string.

Also wires `BLOCKSCOUT_API_KEY` into the test env: the existing Blockscout online tests already reference `env["BLOCKSCOUT_API_KEY"]`, but the whitelist in `src/__tests__/env.ts` never included it, so those tests have always run keyless.

## Possible follow-up

With this in place, `defaultsWithEnv` could include a `BlockscoutABILoader` when `env.BLOCKSCOUT_API_KEY` is set, wired to `CHAIN_ID` like the other two loaders.  Left out here since it changes default behavior; happy to add it here or in a follow-up.