### PR TITLE
loaders: SourcifyABILoader v2 follow-ups

### DIFF
--- a/src/__tests__/loaders.test.ts
+++ b/src/__tests__/loaders.test.ts
@@ -5,6 +5,7 @@ import {
   defaultSignatureLookup,
 
   SourcifyABILoader,
+  SourcifyABILoaderError,
   EtherscanV2ABILoader,
   BlockscoutABILoader,
   BlockscoutABILoaderError,
@@ -112,6 +113,11 @@ describe('loaders: ABILoader', () => {
     expect(result.name).toStrictEqual("UniswapV2Router02")
     expect(result.loader?.name).toStrictEqual("SourcifyABILoader");
     expect(result.loaderResult?.compilation).toBeDefined();
+    expect(result.loaderResult?.metadata?.output?.userdoc).toBeDefined();
+    expect(result.loaderResult?.metadata?.output?.devdoc).toBeDefined();
+
+    const sources = result.getSources && await result.getSources();
+    expect(sources && sources[0].content).toContain("pragma solidity");
   })
 
   online_test('SourcifyABILoader_getContract_UniswapV3Factory', async () => {
@@ -248,10 +254,25 @@ describe('loaders: SourcifyABILoader v2', () => {
 
   test('getContract maps the Sourcify v2 contract response', async () => {
     const abi = [{ type: "function", name: "transfer" }];
-    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const metadata = { output: { devdoc: { title: "A token" }, userdoc: {} } };
+    const fetch = vi.fn(async (url: string) => {
       const parsedURL = new URL(url);
       expect(parsedURL.pathname).toBe("/server/v2/contract/8453/0x0000000000000000000000000000000000000001");
-      expect(parsedURL.searchParams.get("fields")).toBe("abi,compilation,sources");
+
+      // Sources are large, so they're only fetched when getSources() is called
+      if (parsedURL.searchParams.get("fields") === "sources") {
+        return {
+          ok: true,
+          json: async () => ({
+            sources: {
+              "Token.sol": { content: "contract Token {}" },
+            },
+            match: "match",
+          }),
+        };
+      }
+
+      expect(parsedURL.searchParams.get("fields")).toBe("abi,compilation,metadata");
       return {
         ok: true,
         json: async () => ({
@@ -264,13 +285,12 @@ describe('loaders: SourcifyABILoader v2', () => {
               optimizer: { runs: 200 },
             },
           },
-          sources: {
-            "Token.sol": { content: "contract Token {}" },
-          },
+          metadata,
           match: "match",
         }),
       };
-    }));
+    });
+    vi.stubGlobal("fetch", fetch);
 
     const loader = new SourcifyABILoader({ chainId: 8453 });
     const result = await loader.getContract("0x0000000000000000000000000000000000000001");
@@ -283,7 +303,40 @@ describe('loaders: SourcifyABILoader v2', () => {
       compilerVersion: "0.8.30+commit.73712a01",
       runs: 200,
     });
+    expect(result.loaderResult?.metadata).toStrictEqual(metadata);
+    expect(fetch).toHaveBeenCalledOnce();
+
     await expect(result.getSources?.()).resolves.toStrictEqual([{ path: "Token.sol", content: "contract Token {}" }]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('treats a 404 as unverified', async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    })));
+
+    const loader = new SourcifyABILoader({ chainId: 8453 });
+    const address = "0x0000000000000000000000000000000000000001";
+
+    await expect(loader.loadABI(address)).resolves.toStrictEqual([]);
+    const r = await loader.getContract(address);
+    expect(r.ok).toBeFalsy();
+    expect(r.abi).toStrictEqual([]);
+  });
+
+  test('propagates network failures instead of reporting unverified', async () => {
+    // The v1 API returned strict CORS on a miss, so "Failed to fetch" used to
+    // read as not-found; with v2 it's a real failure and must surface, or
+    // MultiABILoader would report "unverified" while Sourcify was unreachable.
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new TypeError("Failed to fetch") }));
+
+    const loader = new SourcifyABILoader({ chainId: 8453 });
+    const address = "0x0000000000000000000000000000000000000001";
+
+    await expect(loader.loadABI(address)).rejects.toThrow(SourcifyABILoaderError);
+    await expect(loader.getContract(address)).rejects.toThrow(SourcifyABILoaderError);
   });
 });
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -327,11 +327,12 @@ export class EtherscanV1ABILoader extends EtherscanV2ABILoader {
 };
 
 function isSourcifyNotFound(error: any): boolean {
-    return (
-        // Sourcify returns strict CORS only if there is no result -_-
-        error.message === "Failed to fetch" ||
-        error.status === 404
-    );
+    // Note: The v1 API returned strict CORS on a miss, so "Failed to fetch"
+    // used to imply not-found. The v2 API serves proper CORS headers and a
+    // real 404, so a network-level failure is a failure again: treating it as
+    // a miss would let MultiABILoader report "unverified" while Sourcify was
+    // merely unreachable.
+    return error.status === 404;
 }
 
 // https://sourcify.dev/
@@ -344,26 +345,46 @@ export class SourcifyABILoader implements ABILoader {
         this.chainId = config?.chainId ?? 1;
     }
 
+    /** @deprecated Source paths from the API v2 are no longer prefixed, so stripping is unnecessary for new results. */
     static stripPathPrefix(path: string): string {
         return path.replace(/^\/contracts\/(full|partial)_match\/\d*\/\w*\/(sources\/)?/, "");
     }
 
-    async #loadContract(address: string): Promise<ContractResult> {
+    #contractURL(address: string, fields: string): URL {
         const url = new URL(`https://sourcify.dev/server/v2/contract/${this.chainId}/${address}`);
-        url.searchParams.set("fields", "abi,compilation,sources");
+        url.searchParams.set("fields", fields);
+        return url;
+    }
+
+    async #loadSources(address: string): Promise<ContractSources> {
+        const url = this.#contractURL(address, "sources");
 
         try {
             const result = await fetchJSON(url.toString()) as SourcifyContractResult;
-            const sources = result.sources ?? {};
+            return Object.entries(result.sources ?? {}).map(([path, source]) => { return { path, content: source.content } });
+        } catch (err: any) {
+            throw new SourcifyABILoaderError("SourcifyABILoader getSources error: " + err.message, {
+                context: { address, url: url.toString() },
+                cause: err,
+            });
+        }
+    }
+
+    async #loadContract(address: string): Promise<ContractResult> {
+        const url = this.#contractURL(address, "abi,compilation,metadata");
+
+        try {
+            const result = await fetchJSON(url.toString()) as SourcifyContractResult;
             const settings = result.compilation?.compilerSettings;
 
             return {
-                abi: result.abi,
+                abi: result.abi ?? [],
                 name: result.compilation?.name ?? null,
                 evmVersion: settings?.evmVersion,
                 compilerVersion: result.compilation?.compilerVersion,
                 runs: settings?.optimizer?.runs,
-                getSources: async () => Object.entries(sources).map(([path, source]) => { return { path, content: source.content } }),
+                // Sources can be large, so they're fetched separately and only on demand
+                getSources: () => this.#loadSources(address),
                 ok: result.match === "match" || result.match === "exact_match",
                 loader: this,
                 loaderResult: result,
@@ -382,12 +403,11 @@ export class SourcifyABILoader implements ABILoader {
     }
 
     async loadABI(address: string): Promise<any[]> {
-        const url = new URL(`https://sourcify.dev/server/v2/contract/${this.chainId}/${address}`);
-        url.searchParams.set("fields", "abi");
+        const url = this.#contractURL(address, "abi");
 
         try {
             const result = await fetchJSON(url.toString()) as SourcifyContractResult;
-            return result.abi;
+            return result.abi ?? [];
         } catch (err: any) {
             if (isSourcifyNotFound(err)) return [];
             throw new SourcifyABILoaderError("SourcifyABILoader loadABI error: " + err.message, {
@@ -435,6 +455,8 @@ export interface SourcifyContractResult {
         name?: string;
         fullyQualifiedName?: string;
     };
+    /// Solc/Vyper standard metadata, carrying the Natspec devdoc/userdoc
+    metadata?: SourcifyContractMetadata;
     sources?: Record<string, { content: string }>;
     match?: "match" | "exact_match" | string;
 }


### PR DESCRIPTION
Follow-ups to the Sourcify API v2 migration in #207 (thanks @stephancill!).  I had a parallel v2 migration in flight and rebased the deltas on top of the merged version; this is now a small behavior-preserving cleanup rather than a rewrite.

## Changes

**Fetch sources lazily.**  `getContract()` requested `fields=abi,compilation,sources`, downloading the full source tree on every lookup (UniswapV3Factory returns 390 source files) even though `autoload()` never reads them.  `getSources()` now issues its own `fields=sources` request only when called, which is the "could trigger additional fetch requests" behavior its docstring already anticipates.

**Restore Natspec docs in `loaderResult`.**  The v1 loader exposed the solc metadata (with `output.devdoc`/`userdoc`, deliberately added in #116) as `loaderResult`; the v2 migration dropped the `metadata` field, so consumers lost access to the docs.  `getContract()` now requests `abi,compilation,metadata`, and `loaderResult.metadata` carries them again.  Name resolution is untouched (`compilation.name`, as merged in #207).

**Treat only a 404 as not-found.**  `isSourcifyNotFound` still matched `"Failed to fetch"`, a workaround for the v1 API returning strict CORS on a miss.  The v2 API serves proper CORS headers and a real 404, so keeping the check converts a network-level Sourcify outage into a clean miss; combined with #204's semantics, `MultiABILoader` could then report "unverified" while Sourcify was merely unreachable, the exact false-miss #204 guards against.  There's a new mocked test codifying this.

**Guard `abi` with `?? []`** so an unexpected response shape can't propagate `undefined` into `MultiABILoader`'s `r.abi.length` check.

**Deprecate `stripPathPrefix`.**  v2 source paths come back unprefixed, so it's unnecessary for new results; kept exported since it's public API.

## Testing

- Extended the mocked v2 tests: `getContract` now asserts the two-request lazy-sources flow and the `metadata` passthrough; new tests cover 404-as-unverified and network-failure-as-error.
- Extended the online `SourcifyABILoader_getContract` test to assert `loaderResult.metadata.output.{devdoc,userdoc}` and exercise the lazy `getSources()` path.
- `ONLINE=1 vitest run src/__tests__/loaders.test.ts -t Sourcify`: 12 passed against the live API.  Full offline suite passes.  (The Etherscan online tests fail identically on clean main in my environment for lack of an API key.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)