### PR TITLE
disasm: fix CBOR metadata boundary in the aux-data proxy slot scan

### DIFF
--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -75,6 +75,69 @@ describe('proxy detection', () => {
     });
 });
 
+describe('proxy detection in the data segment', () => {
+    // These are hand-built bytecodes for exercising the scan that looks for known
+    // proxy slots in the data that lives after the end of the program:
+    //
+    //   600080fd        PUSH1 0x00 DUP1 REVERT   <- program, ends in a halt
+    //   <data segment>                           <- everything after the halt
+    //
+    // We only reach that scan when no proxy was found in the program itself, so
+    // the program here is deliberately trivial.
+    const HALTING_PROGRAM = "600080fd";
+
+    // Filler so that the data segment is long enough to be scanned even when the
+    // end boundary is computed too aggressively.
+    const FILLER = "11".repeat(32);
+
+    // A solc-style CBOR metadata blob followed by its 2-byte big-endian length,
+    // which is what solc appends to runtime bytecode:
+    //   {"ipfs": <34-byte multihash>, "solc": <3 bytes>}
+    // The blob itself is 51 bytes here, same as the real-world contract that
+    // prompted this test, so the trailing length bytes are 0x0033.
+    function cborMetadata(digest: string): string {
+        const blob =
+            "a2" +                       // map(2)
+            "64" + "69706673" +          // "ipfs"
+            "5822" + "1220" + digest +   // bytes(34): sha2-256 multihash
+            "64" + "736f6c63" +          // "solc"
+            "43" + "000606";             // bytes(3): 0.6.6
+        const length = blob.length / 2;
+        return blob + length.toString(16).padStart(4, "0");
+    }
+
+    const EIP1967_IMPL = proxies.slots.EIP1967_IMPL.slice(2);
+
+    test('Slot ending flush against the CBOR metadata', async () => {
+        // The slot value is the last thing before the metadata blob, so any
+        // over-trimming of the metadata clips the tail of the slot and hides it.
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + EIP1967_IMPL + cborMetadata("aa".repeat(32));
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["EIP1967Proxy"]);
+    });
+
+    test('Slot inside the CBOR metadata is not a match', async () => {
+        // Same shape, except the slot value only appears within the metadata blob.
+        // Metadata is compiler output, not program data, so it stays out of the scan.
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + FILLER + cborMetadata(EIP1967_IMPL);
+
+        const program = disasm(bytecode);
+        expect(program.proxies).toEqual([]);
+    });
+
+    test('Trailing bytes that are not a CBOR length', async () => {
+        // Creation bytecode ends with constructor arguments, not with a metadata
+        // length. Here the final 2 bytes (0x99a7) would be read as a 39335-byte
+        // blob, which is longer than the whole bytecode.
+        const constructorArgs = "000000000000000000000000490e379c9cff64944be82b849f8fd5972c7999a7";
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + EIP1967_IMPL + cborMetadata("aa".repeat(32)) + constructorArgs;
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["EIP1967Proxy"]);
+    });
+});
+
 describe('known proxy resolving', () => {
     online_test('Safe: Proxy Factory 1.1.1', async ({ provider }) => {
         const address = "0x655a9e6b044d6b62f393f9990ec3ea877e966e18";

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -535,7 +535,16 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
         const finalByte = code.bytecode.slice(-1)[0];
         if (!isHalt(finalByte)) {
             const cborLength = valueToOffset(code.bytecode.slice(-2));
-            endBoundary = -(cborLength + 4); // +4 for the length bytes
+            const metadataLength = cborLength + 2; // +2 for the length bytes, which are not counted in cborLength
+            const blobStart = code.bytecode.length - metadataLength;
+
+            // The trailing 2 bytes are only a CBOR length if the blob they imply fits
+            // inside the data segment and starts with a CBOR map header (solc emits
+            // 0xa1/0xa2/0xa3). If we were handed creation bytecode then the tail is
+            // constructor arguments and this number is meaningless, in which case we'd
+            // rather not trim at all than trim garbage.
+            const looksLikeCBOR = blobStart >= boundaryPos && (code.bytecode[blobStart] & 0xe0) === 0xa0;
+            if (looksLikeCBOR) endBoundary = -metadataLength;
         }
 
         const auxData = bytesToHex(code.bytecode.slice(boundaryPos, endBoundary));


### PR DESCRIPTION
When `disasm` finds no proxy in the program itself, it scans the leftover data after the end of the program for known proxy storage slots. Before scanning, it tries to cut off the CBOR metadata that solc appends. Two things go wrong there.

### Bug 1: the metadata suffix is two bytes longer than it really is

```ts
endBoundary = -(cborLength + 4); // +4 for the length bytes
```

solc appends a CBOR blob of `cborLength` bytes, then 2 bytes holding that length. So the suffix to skip is `cborLength + 2`. `code.bytecode` is a `Uint8Array`, so slice indices are counted in bytes — the `4` looks like it came from counting the length field in hex characters instead.

The effect is that two bytes of real data are thrown away from the scanned region on every contract. If a slot value happens to sit flush against the metadata, its last two bytes get clipped and it is never matched.

Concretely, on Polygon DAI (`0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063`, chain 137), which I used while looking into this:

```
total runtime bytes:        2949
cborLength (last 2 bytes):    51
real metadata starts at:    2896
whatsabi cuts off at:       2894   <- 2 bytes early
```

The blob at 2896 starts `a2 64 69 70 66 73` (CBOR `map(2)`, then the text `ipfs`) and ends with `solc` 0.6.6, which confirms the `+2` arithmetic.

### Bug 2: the last two bytes are assumed to be a CBOR length

That is true for runtime bytecode. It is not true for creation bytecode, where the tail is constructor arguments. The existing `if (!isHalt(finalByte))` guard does not catch this, and a nonsense length produces an empty slice, so the scan silently does nothing.

Same contract, creation bytecode:

```
last 32 bytes: 000000000000000000000000490e379c9cff64944be82b849f8fd5972c7999a7
last 2 bytes (0x99a7) read as cborLength: 39335
endBoundary: -36102  ->  slice(3046, -36102) = empty
```

### The fix

Use `cborLength + 2`, and only trim when the trailing bytes plausibly *are* a metadata length: the implied blob has to fit inside the data segment, and it has to begin with a CBOR map header (`0xa1`/`0xa2`/`0xa3` from solc; the check masks the whole CBOR major-type-5 range). When that does not hold, don't trim at all rather than trim a garbage amount.

This only ever widens the scanned window, so it can add detections but never remove them.

### Testing

Three new tests in `src/__tests__/proxies.test.ts`, built on hand-made bytecode: a trivial halting program followed by a data segment containing the EIP-1967 implementation slot and a realistic 51-byte solc metadata blob.

- **Slot ending flush against the CBOR metadata** — fails on `main`, passes with the fix. Covers bug 1.
- **Trailing bytes that are not a CBOR length** — fails on `main`, passes with the fix. Covers bug 2.
- **Slot inside the CBOR metadata is not a match** — passes both before and after. It is a guard against someone later dropping the trimming altogether, not a test of this change.

I used synthetic bytecode because I could not find a real contract where this fix alone flips the outcome. On the Polygon DAI contract above, detection is still empty before and after: recognizing that one also needs a separate change (matching the pre-image of the slot hash), which I'm keeping out of this PR.

What I ran:

- `npm test` — 91 passed / 53 skipped before, 94 passed / 53 skipped after (the 3 new tests). No other change.
- `ONLINE=1 npm test` — same 11 failures before and after, all `EtherscanV2ABILoader` "Missing/Invalid API Key" because I have no Etherscan key. All of `proxies.test.ts` passes online, including the `comprehensive proxy detection` block.
- Ran `disasm` over 187 live mainnet contracts (sampled from recent blocks) with and without the patch and diffed the detected proxies and selector counts: identical. So no new false positives in that sample.

What I did **not** verify: whether this changes anything on chains or contract shapes outside that sample.

### Follow-up

I have a separate change that builds on this one, adding recognition for the Polygon `UpgradableProxy` slot layout. Deliberately not included here so this stays a self-contained boundary fix.

Downstream context: https://github.com/argotorg/sourcify/issues/2923 — Sourcify's proxy detection misses Polygon's `UpgradableProxy`, and these boundary bugs are part of why. Related but distinct: #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
