### PR TITLE
Extract and detect CBOR metadata in contract bytecode

### DIFF
--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -75,6 +75,69 @@ describe('proxy detection', () => {
     });
 });
 
+describe('proxy detection in the data segment', () => {
+    // These are hand-built bytecodes for exercising the scan that looks for known
+    // proxy slots in the data that lives after the end of the program:
+    //
+    //   600080fd        PUSH1 0x00 DUP1 REVERT   <- program, ends in a halt
+    //   <data segment>                           <- everything after the halt
+    //
+    // We only reach that scan when no proxy was found in the program itself, so
+    // the program here is deliberately trivial.
+    const HALTING_PROGRAM = "600080fd";
+
+    // Filler so that the data segment is long enough to be scanned even when the
+    // end boundary is computed too aggressively.
+    const FILLER = "11".repeat(32);
+
+    // A solc-style CBOR metadata blob followed by its 2-byte big-endian length,
+    // which is what solc appends to runtime bytecode:
+    //   {"ipfs": <34-byte multihash>, "solc": <3 bytes>}
+    // The blob itself is 51 bytes here, same as the real-world contract that
+    // prompted this test, so the trailing length bytes are 0x0033.
+    function cborMetadata(digest: string): string {
+        const blob =
+            "a2" +                       // map(2)
+            "64" + "69706673" +          // "ipfs"
+            "5822" + "1220" + digest +   // bytes(34): sha2-256 multihash
+            "64" + "736f6c63" +          // "solc"
+            "43" + "000606";             // bytes(3): 0.6.6
+        const length = blob.length / 2;
+        return blob + length.toString(16).padStart(4, "0");
+    }
+
+    const EIP1967_IMPL = proxies.slots.EIP1967_IMPL.slice(2);
+
+    test('Slot ending flush against the CBOR metadata', async () => {
+        // The slot value is the last thing before the metadata blob, so any
+        // over-trimming of the metadata clips the tail of the slot and hides it.
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + EIP1967_IMPL + cborMetadata("aa".repeat(32));
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["EIP1967Proxy"]);
+    });
+
+    test('Slot inside the CBOR metadata is not a match', async () => {
+        // Same shape, except the slot value only appears within the metadata blob.
+        // Metadata is compiler output, not program data, so it stays out of the scan.
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + FILLER + cborMetadata(EIP1967_IMPL);
+
+        const program = disasm(bytecode);
+        expect(program.proxies).toEqual([]);
+    });
+
+    test('Trailing bytes that are not a CBOR length', async () => {
+        // Creation bytecode ends with constructor arguments, not with a metadata
+        // length. Here the final 2 bytes (0x99a7) would be read as a 39335-byte
+        // blob, which is longer than the whole bytecode.
+        const constructorArgs = "000000000000000000000000490e379c9cff64944be82b849f8fd5972c7999a7";
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + EIP1967_IMPL + cborMetadata("aa".repeat(32)) + constructorArgs;
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["EIP1967Proxy"]);
+    });
+});
+
 describe('known proxy resolving', () => {
     online_test('Safe: Proxy Factory 1.1.1', async ({ provider }) => {
         const address = "0x655a9e6b044d6b62f393f9990ec3ea877e966e18";

--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -138,6 +138,38 @@ describe('proxy detection in the data segment', () => {
     });
 });
 
+describe('metadata extraction', () => {
+    const HALTING_PROGRAM = "600080fd";
+    const FILLER = "11".repeat(32);
+
+    test('solc {ipfs, solc} metadata is extracted', async () => {
+        const digest = "ab".repeat(32);
+        const metadata =
+            "a2" +                       // map(2)
+            "64" + "69706673" +          // "ipfs"
+            "5822" + "1220" + digest +   // bytes(34): sha2-256 multihash
+            "64" + "736f6c63" +          // "solc"
+            "43" + "000606" +            // bytes(3): 0.6.6
+            "0033";                      // 51-byte blob length
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + metadata;
+
+        const program = disasm(bytecode);
+        expect(program.metadata).toEqual({
+            ipfs: "0x1220" + digest,
+            solc: "0x000606",
+        });
+    });
+
+    test('no metadata extracted from constructor arguments', async () => {
+        // Creation bytecode tail is constructor arguments, not CBOR metadata.
+        const constructorArgs = "000000000000000000000000490e379c9cff64944be82b849f8fd5972c7999a7";
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + constructorArgs;
+
+        const program = disasm(bytecode);
+        expect(program.metadata).toBeUndefined();
+    });
+});
+
 describe('known proxy resolving', () => {
     online_test('Safe: Proxy Factory 1.1.1', async ({ provider }) => {
         const address = "0x655a9e6b044d6b62f393f9990ec3ea877e966e18";

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -538,15 +538,16 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
         // constructor arguments and this number is meaningless, in which case we'd
         // rather not trim at all than trim garbage.
         const looksLikeCBOR = blobStart >= boundaryPos && (code.bytecode[blobStart] & 0xe0) === 0xa0;
-        if (looksLikeCBOR) endBoundary = -metadataLength;
+        if (looksLikeCBOR) {
+            endBoundary = -metadataLength;
 
-        const cborData = code.bytecode.slice(endBoundary).slice(0, -2);
-
-        if (cborData.length === 51) {
-            // We're going to cheat if we suspect it's {ipfs, solc}
-            p.metadata = {
-                ipfs: bytesToHex(cborData.slice(8, 42)),  // 2 bytes map + 6 bytes "ipfs" for 34 bytes value
-                solc: bytesToHex(cborData.slice(48, 51)),  // 2 bytes map + 6 bytes "solc" for 3 bytes value
+            const cborData = code.bytecode.slice(blobStart, -2);
+            if (cborData.length === 51) {
+                // We're going to cheat if we suspect it's {ipfs, solc}
+                p.metadata = {
+                    ipfs: bytesToHex(cborData.slice(8, 42)),  // 2 bytes map + 6 bytes "ipfs" for 34 bytes value
+                    solc: bytesToHex(cborData.slice(48, 51)),  // 2 bytes map + 6 bytes "solc" for 3 bytes value
+                }
             }
         }
     }

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -155,6 +155,7 @@ export class Program {
     proxies: Array<ProxyResolver>;
     isFactory: boolean; // CREATE or CREATE2 detected
     sstoreCount: number; // Number of SSTORE instructions detected, used to determine if this may be a destination contract (vs a proxy)
+    metadata?: Record<string, string>; // CBOR metadata at the end of the contract
 
     init?: Program; // Program embedded as init code
 
@@ -522,22 +523,30 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
         }
     }
 
+    let endBoundary : number|undefined = undefined;
+    const finalByte = code.bytecode.slice(-1)[0];
+    // Try to detect CBOR metadata (vs bytecode that does not include it)
+    // https://playground.sourcify.dev/
+    if (!isHalt(finalByte) || code.bytecode.slice(-2)[0] === 0) {
+        const cborLength = valueToOffset(code.bytecode.slice(-2));
+        endBoundary = -(cborLength + 2); // +4 for the length bytes
+        const cborData = code.bytecode.slice(endBoundary).slice(0, -2);
+
+        if (cborData.length === 51) {
+            // We're going to cheat if we suspect it's {ipfs, solc}
+            p.metadata = {
+                ipfs: bytesToHex(cborData.slice(8, 42)),  // 2 bytes map + 6 bytes "ipfs" for 34 bytes value
+                solc: bytesToHex(cborData.slice(48, 51)),  // 2 bytes map + 6 bytes "solc" for 3 bytes value
+            }
+        }
+    }
+
     if ((boundaryPos > 0 && p.proxies.length === 0)) {
         // Slots could be stored outside of the program boundary and copied in
         // and we haven't found any proxy slots yet so let's check just in case...
         // This is unstructured data, so it could be anything. We can't parse it reliably.
 
         // We can skip the CBOR encoding based on length defined in the final byte
-        // https://playground.sourcify.dev/
-
-        // TODO: Pull CBOR out and add to result
-        let endBoundary : number|undefined = undefined;
-        const finalByte = code.bytecode.slice(-1)[0];
-        if (!isHalt(finalByte)) {
-            const cborLength = valueToOffset(code.bytecode.slice(-2));
-            endBoundary = -(cborLength + 4); // +4 for the length bytes
-        }
-
         const auxData = bytesToHex(code.bytecode.slice(boundaryPos, endBoundary));
         if (auxData.length >= 2 + 64) { // 0x is empty, plus at least enough for a slot
             // Look for known slots in extra data segment that could be CODECOPY'd

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -529,7 +529,17 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
     // https://playground.sourcify.dev/
     if (!isHalt(finalByte) || code.bytecode.slice(-2)[0] === 0) {
         const cborLength = valueToOffset(code.bytecode.slice(-2));
-        endBoundary = -(cborLength + 2); // +4 for the length bytes
+        const metadataLength = cborLength + 2; // +2 for the length bytes, which are not counted in cborLength
+        const blobStart = code.bytecode.length - metadataLength;
+
+        // The trailing 2 bytes are only a CBOR length if the blob they imply fits
+        // inside the data segment and starts with a CBOR map header (solc emits
+        // 0xa1/0xa2/0xa3). If we were handed creation bytecode then the tail is
+        // constructor arguments and this number is meaningless, in which case we'd
+        // rather not trim at all than trim garbage.
+        const looksLikeCBOR = blobStart >= boundaryPos && (code.bytecode[blobStart] & 0xe0) === 0xa0;
+        if (looksLikeCBOR) endBoundary = -metadataLength;
+
         const cborData = code.bytecode.slice(endBoundary).slice(0, -2);
 
         if (cborData.length === 51) {


### PR DESCRIPTION
## Summary

Combines the WIP CBOR work from #145 with the boundary fix and tests from #211, then layers our changes on top. The history is arranged so each prior contribution lands as its own commit under its original author, and what we added here is visible as a separate step.

### Commits

| Commit | Author | What |
| --- | --- | --- |
| `disasm: Add experimental CBOR parsing for EVM metadata` | @shazow | Cherry-picked from #145. Moves the CBOR block out of the proxy slot scan so metadata is parsed for every program, adds `Program.metadata`, and fixes the length arithmetic to `cborLength + 2`. |
| `disasm: fix CBOR metadata boundary in the aux-data proxy slot scan` | @kuzdogan | Cherry-picked from #211. Adds the plausibility guard and the three data-segment tests. |
| `disasm: Only parse CBOR metadata when the boundary check passes` | — | New here. |
| `tests: Cover CBOR metadata extraction` | — | New here. |

### How the two PRs relate

#211 identified two bugs. #145 already fixed the first one and not the second:

1. **Off-by-two trim** — `endBoundary = -(cborLength + 4)` discards two bytes of real data from the scanned region on every contract, so a slot sitting flush against the metadata gets its tail clipped and is never matched. #145 already had `+2` here.
2. **Trailing bytes assumed to be a CBOR length** — true for runtime bytecode, false for creation bytecode where the tail is constructor arguments. A nonsense length yields an empty slice and the scan silently does nothing. #145 did **not** address this; #211's "Trailing bytes that are not a CBOR length" test fails against #145 alone.

So #145 needed #211's guard, and #211's guard needed rebasing onto the block #145 moved.

### Changes made here on top

- **Gate the metadata parse on the same boundary check.** #211's guard decided whether to trim, but #145's metadata parse still ran on whatever the trailing length pointed at. When the tail is not metadata that slice is the whole data segment, and a 51-byte one would be reported as an `{ipfs, solc}` blob. Both decisions now come from `looksLikeCBOR`.
- **Two tests for the metadata extraction** that #145 uniquely adds: a solc `{ipfs, solc}` blob is parsed into `program.metadata`, and a constructor-args tail is not mistaken for one. #211's tests cover the slot scan; these cover the other half of the same code path.
- Adaptations needed to make #145's commit build on current main: dropped the `cborMapDecoder` import (no such export in `utils`) and made `Program.metadata` optional, since it is not always populated.

### Testing

- The 3 tests from #211 and the 2 added here pass.
- Full offline suite has an identical failure set to `main` (all network-gated tests failing on RPC egress in the sandbox), verified by diffing failure lists between this branch and a `main` worktree.
- `tsc --noEmit` clean.
- #211's tests were checked to pass at @kuzdogan's commit too, so the history bisects cleanly.

### Still open

- The 51-byte length check only recognizes the exact `{ipfs, solc}` shape. Other shapes (`bzzr0`/`bzzr1`, `experimental`, no `solc` key) are silently skipped — presumably what the `cborMapDecoder` in #145 was heading toward.
- `metadata` is not plumbed through `auto.ts` / `AutoloadResult` yet.
- @kuzdogan has a follow-up adding the Polygon `UpgradableProxy` slot layout, which builds on #211. Downstream context: argotorg/sourcify#2923. Related: #67.

https://claude.ai/code/session_01Dg1hcYeCCxHuszqpc8bgbM