### PR TITLE
proxies: Add Polygon (Matic) UpgradableProxy support

### DIFF
--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -4,6 +4,7 @@ import { cached_test, online_test, makeProvider } from './env';
 
 import { disasm } from '../disasm';
 import { addSlotOffset, readArray, joinSlot } from "../slots.js";
+import { bytesToHex, keccak256 } from '../utils';
 import * as proxies from '../proxies';
 
 import { ZEPPELINOS_USDC, WANDERWING } from './__fixtures__/proxies'
@@ -135,6 +136,34 @@ describe('proxy detection in the data segment', () => {
 
         const program = disasm(bytecode);
         expect(program.proxies.map(p => p.name)).toEqual(["EIP1967Proxy"]);
+    });
+
+    // Polygon's UpgradableProxy hashes this string at runtime instead of embedding
+    // the slot value, so the data segment carries the string and not the hash.
+    const MATIC_SLOT_STRING = "matic.network.proxy.implementation";
+    const MATIC_PREIMAGE = bytesToHex(new TextEncoder().encode(MATIC_SLOT_STRING)).slice(2);
+
+    test('Slot pre-image in the data segment is a match', async () => {
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + MATIC_PREIMAGE + cborMetadata("aa".repeat(32));
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["MaticProxy"]);
+    });
+
+    test('Matic slot value in the data segment is a match', async () => {
+        // A solc new enough to fold the keccak256 into a constant emits the slot
+        // value itself, which the ordinary slot scan picks up without the pre-image.
+        const bytecode = "0x" + HALTING_PROGRAM + FILLER + proxies.slots.MATIC_IMPL.slice(2) + cborMetadata("aa".repeat(32));
+
+        const program = disasm(bytecode);
+        expect(program.proxies.map(p => p.name)).toEqual(["MaticProxy"]);
+    });
+
+    test('Matic pre-image and slot constants agree', async () => {
+        // Both constants are opaque hex in the source. Pin them to the string they
+        // are derived from, so a typo fails here instead of silently never matching.
+        expect(Object.keys(proxies.slotPreimages)).toContain("0x" + MATIC_PREIMAGE);
+        expect(keccak256(new TextEncoder().encode(MATIC_SLOT_STRING))).toEqual(proxies.slots.MATIC_IMPL);
     });
 });
 
@@ -279,6 +308,29 @@ describe('contract proxy resolving', () => {
         const got = await resolver.resolve(provider, address);
 
         const wantImplementation = "0x9c13e225ae007731caa49fd17a41379ab1a489f4";
+        expect(got).toEqual(wantImplementation);
+    });
+
+    cached_test('Matic Proxy: DAI on Polygon', async ({ withCache }) => {
+        // Polygon PoS bridged tokens use Polygon's own UpgradableProxy. The slot is
+        // keccak256("matic.network.proxy.implementation"), computed at runtime by
+        // solc 0.6.6, so only the pre-image scan finds it.
+        const provider = makeProvider("https://polygon-bor-rpc.publicnode.com");
+        const address = "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063";
+        const code = await withCache(
+            `polygon-${address}_code`,
+            async () => {
+                return await provider.getCode(address)
+            },
+        );
+
+        const program = disasm(code);
+        expect(program.proxies.map(p => p.name)).toEqual(["MaticProxy"]);
+
+        const resolver = program.proxies[0];
+        const got = await resolver.resolve(provider, address);
+
+        const wantImplementation = "0x490e379c9cff64944be82b849f8fd5972c7999a7";
         expect(got).toEqual(wantImplementation);
     });
 });

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -6,7 +6,7 @@ import { hexToBytes, bytesToHex } from "./utils.js";
 
 import { opcodes, pushWidth, isPush, isLog, isHalt, isCompare } from "./opcodes.js";
 
-import { slotResolvers, SequenceWalletProxyResolver, FixedProxyResolver } from "./proxies.js";
+import { slotResolvers, slotPreimages, SequenceWalletProxyResolver, FixedProxyResolver } from "./proxies.js";
 
 
 function valueToOffset(value: Uint8Array): number {
@@ -563,6 +563,13 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
             // Look for known slots in extra data segment that could be CODECOPY'd
             for (const [slot, resolver] of Object.entries(slotResolvers)) {
                 if (auxData.lastIndexOf(slot.slice(2)) === -1) continue;
+                p.proxies.push(resolver);
+            }
+
+            // Some proxies hash their slot pre-image at runtime rather than embedding
+            // the slot value, so the string itself is what lands in the data segment.
+            for (const [preimage, resolver] of Object.entries(slotPreimages)) {
+                if (auxData.lastIndexOf(preimage.slice(2)) === -1) continue;
                 p.proxies.push(resolver);
             }
         }

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -280,6 +280,17 @@ export class PROXIABLEProxyResolver extends BaseProxyResolver implements ProxyRe
     }
 }
 
+// https://github.com/maticnetwork/pos-portal/blob/master/contracts/common/Proxy/UpgradableProxy.sol
+// Used by the Polygon PoS bridge child tokens. Implementation pointer is stored
+// in a Matic-namespaced slot rather than the EIP-1967 one.
+export class MaticProxyResolver extends BaseProxyResolver implements ProxyResolver {
+    override name = "MaticProxy";
+
+    async resolve(provider: StorageProvider, address: string): Promise<string> {
+        return addressFromPadded(await provider.getStorageAt(address, slots.MATIC_IMPL));
+    }
+}
+
 // https://github.com/0xsequence/wallet-contracts/blob/master/contracts/Wallet.sol
 // Implementation pointer is stored in slot keyed on the deployed address.
 export class SequenceWalletProxyResolver extends BaseProxyResolver implements ProxyResolver {
@@ -348,6 +359,11 @@ export const slots : Record<string, string> = {
     // Same as above but some implementations don't do -1
     DIAMOND_STORAGE_1: "0xc8fcad8db84d3cc18b4c41d551ea0ee66dd599cde068d998e57d5e09332c131c",
 
+    // Polygon (Matic) UpgradableProxy, used by the PoS bridge child tokens
+    // https://github.com/maticnetwork/pos-portal/blob/master/contracts/common/Proxy/UpgradableProxy.sol
+    // keccak256("matic.network.proxy.implementation")
+    MATIC_IMPL: "0xbaab7dbf64751104133af04abc7d9979f0fda3b059a322a8333f533d3f32bf7f",
+
     // EIP-1167 minimal proxy standard
     // Parsed in disasm
 }
@@ -361,6 +377,7 @@ export const slotResolvers : Record<string, ProxyResolver> = {
     [slots.GNOSIS_SAFE_SELECTOR]: new GnosisSafeProxyResolver("GnosisSafeProxy"),
     [slots.DIAMOND_STORAGE]: new DiamondProxyResolver("DiamondProxy"),
     [slots.DIAMOND_STORAGE_1]: new DiamondProxyResolver("DiamondProxy", slots.DIAMOND_STORAGE_1),
+    [slots.MATIC_IMPL]: new MaticProxyResolver("MaticProxy"),
 
     // Not sure why, there's a compiler optimization that adds 1 or 2 to the normal slot?
     // Would love to understand this, if people have ideas
@@ -368,4 +385,29 @@ export const slotResolvers : Record<string, ProxyResolver> = {
 
     // Off-by-one slot version of EIP1967, some examples in the wild who choose to do the -1 at runtime (See issue #178)
     "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbd": new EIP1967ProxyResolver("EIP1967Proxy"),
+};
+
+
+/**
+ * Slot pre-images to look for in the data segment, mapped to the resolver for
+ * the slot they hash to.
+ *
+ * Normally a proxy embeds its slot as a PUSH32 constant, and we match that value
+ * directly via {@link slotResolvers}. Some proxies instead keep the pre-image
+ * string in their data segment and hash it at runtime, so the slot value never
+ * appears in the bytecode at all and there is nothing for that scan to match.
+ *
+ * This happens when the source writes the slot as an expression rather than as a
+ * hex literal, and the compiler does not fold it. Polygon's UpgradableProxy is
+ * one such contract: it declares the slot as
+ * `keccak256("matic.network.proxy.implementation")` and solc 0.6.6 inlines that
+ * expression at each use site, so the string ships and the hash is computed on
+ * every call.
+ *
+ * Keys are the hex encoding of the ASCII pre-image, so that the data segment
+ * scan in disasm can match them the same way it matches slot values.
+ */
+export const slotPreimages : Record<string, ProxyResolver> = {
+    // "matic.network.proxy.implementation" -> slots.MATIC_IMPL
+    "0x6d617469632e6e6574776f726b2e70726f78792e696d706c656d656e746174696f6e": slotResolvers[slots.MATIC_IMPL],
 };


### PR DESCRIPTION
Polygon's `UpgradableProxy` keeps its implementation pointer at `keccak256("matic.network.proxy.implementation")` instead of the EIP-1967 slot, so whatsabi does not detect it. This is the proxy the Polygon PoS bridge uses for child tokens, so it covers most bridged assets on that chain. Spot-checking the big ones — reading the slot directly against what `disasm` currently reports:

| token | address | slot holds | detected |
| --- | --- | --- | --- |
| DAI (PoS) | `0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063` | `0x490e379c…99a7` | no |
| USDC (PoS) | `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` | `0xdd9185db…2226` | no |
| USDT (PoS) | `0xc2132D05D31c914a87C6611C10748AEb04B58e8F` | `0x90040487…4229` | no |
| WBTC (PoS) | `0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6` | `0x7ffb3d63…c1e2` | no |

### Adding the slot alone does not fix it

The proxy declares the slot as an expression:

```solidity
bytes32 constant IMPLEMENTATION_SLOT = keccak256("matic.network.proxy.implementation");
```

solc 0.6.6 inlines that expression at each use site instead of folding it to a value. So the deployed code carries the **ASCII string** in its data segment and runs `KECCAK256` on it at call time. The hash `0xbaab7dbf…` is never pushed, which means neither the `PUSH32` scan nor the data-segment slot scan has anything to match.

Compare that with the OpenZeppelin style, where the slot is written as a hex literal and the keccak expression is only a comment — that always compiles to a `PUSH32`, on any compiler version.

### What this adds

1. `slots.MATIC_IMPL` and a `MaticProxyResolver`, registered in `slotResolvers`. It follows `ZeppelinOSProxyResolver` and `PROXIABLEProxyResolver` exactly — one `getStorageAt`, no extra calls. This covers builds where the compiler *does* fold the constant.
2. `slotPreimages`, a table of slot pre-images keyed by their hex encoding, matched in the same data-segment scan as `slotResolvers`. This covers the builds where it does not.

The pre-image scan sits inside the existing `boundaryPos > 0 && p.proxies.length === 0` block, so it only runs when nothing was found in the program itself and cannot override stronger evidence.

One note on style: I gave `slotPreimages` a TSDoc block rather than the `//` comment this file otherwise uses for exports. It introduces a mechanism rather than another constant, and TSDoc renders as prose in the generated docs. Happy to change it back.

This builds on the boundary fix from #213. Before that, the string was either clipped by the metadata over-trim or the scanned region came out empty, so no amount of pre-image matching would have found it.

### Testing

Four tests. Two are gated on the `disasm.ts` change and two on the `proxies.ts` change — I verified that split by stashing `src/disasm.ts` and re-running, which fails exactly the two that should:

```
FAIL  proxy detection in the data segment > Slot pre-image in the data segment is a match
FAIL  contract proxy resolving > Matic Proxy: DAI on Polygon
```

- **Slot pre-image in the data segment** — hand-built bytecode, offline, in the existing data-segment `describe`.
- **Matic slot value in the data segment** — the folded case, covering the `slotResolvers` entry on its own.
- **Matic pre-image and slot constants agree** — both new constants are opaque hex, so this pins them to the string they derive from. A typo fails loudly instead of silently never matching.
- **Matic Proxy: DAI on Polygon** — a `cached_test` against a real contract, following the existing Base and Sepolia pattern with a `publicnode` RPC.

What I ran:

- `npm test` — 96 passed / 53 skipped before, 100 passed / 53 skipped after. No other change.
- `npx tsc --noEmit` — clean.
- Disassembled all 17 contracts in `.cache/` with and without the patch and diffed detected proxies plus selector counts. One line changes, the Polygon contract, from `proxies=[]` to `proxies=["MaticProxy"]`. Nothing else moves.
- Checked both bytecode forms of Polygon DAI end to end, since the data segment differs between them:

```
runtime    2949 bytes  proxies=["MaticProxy"]  resolved=0x490e379c9cff64944be82b849f8fd5972c7999a7
creation   3237 bytes  proxies=["MaticProxy"]  resolved=0x490e379c9cff64944be82b849f8fd5972c7999a7
```

What I did **not** verify: any Polygon proxy other than the four tokens above, or whether other chains have contracts whose data segment happens to contain this string.

### Context

Downstream: https://github.com/argotorg/sourcify/issues/2923 — Sourcify reports `isProxy: false` for these tokens and serves the proxy ABI instead of the token ABI. Related but distinct: #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
