### PR TITLE
disasm/proxy: Misc fixes

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -2,6 +2,7 @@ import { expect } from "vitest";
 
 import { whatsabi } from "../index";
 import { autoload } from "../auto";
+import { slots } from "../proxies";
 
 import { test, online_test, cached_test, makeProvider } from "./env";
 
@@ -24,6 +25,32 @@ test('autoload sets hasCode to false if code is empty', async () => {
     const address = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
     await expect(autoload(address, { provider: fakeProvider("0x") })).resolves.toMatchObject({ hasCode: false });
     await expect(autoload(address, { provider: fakeProvider("0x1234") })).resolves.toMatchObject({ hasCode: true });
+});
+
+test('autoload stops following a proxy cycle', async () => {
+    const address = "0x1111111111111111111111111111111111111111";
+    const bytecode = "0x7f" + slots.EIP1967_IMPL.slice(2) + "00";
+    let fetchedCode = false;
+    const provider = {
+        getCode: async () => {
+            expect(fetchedCode).toBe(false);
+            fetchedCode = true;
+            return bytecode;
+        },
+        getStorageAt: async () => "0x" + "00".repeat(12) + address.slice(2),
+        call: async () => "0x",
+        getAddress: async (name: string) => name,
+    };
+
+    const result = await autoload(address, {
+        provider,
+        abiLoader: false,
+        signatureLookup: false,
+        followProxies: true,
+        onError: () => {},
+    });
+
+    expect(result.address).toBe(address);
 });
 
 online_test('autoload selectors', async ({ provider }) => {

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -53,6 +53,25 @@ test('autoload stops following a proxy cycle', async () => {
     expect(result.address).toBe(address);
 });
 
+test('autoload does not follow a zero-address proxy resolution', async () => {
+    const address = "0x2222222222222222222222222222222222222222";
+    const bytecode = "0x7f" + slots.EIP1967_IMPL.slice(2) + "00";
+    const provider = {
+        request: ({ method, params }: { method: string, params: string[] }) =>
+            method === "eth_getCode" && params[0] === address ? bytecode : "0x" + "00".repeat(32),
+    };
+
+    const result = await autoload(address, {
+        provider,
+        abiLoader: false,
+        signatureLookup: false,
+        followProxies: true,
+        onError: () => {},
+    });
+
+    expect(result.address).toBe(address);
+});
+
 online_test('autoload selectors', async ({ provider }) => {
     const address = "0x4A137FD5e7a256eF08A7De531A17D0BE0cc7B6b6"; // Random unverified contract
     const { abi } = await autoload(address, {

--- a/src/__tests__/edges.test.ts
+++ b/src/__tests__/edges.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest';
 
 import { cached_test, describe_cached } from "./env";
 import { selectorsFromBytecode } from '../index';
-import { disasm } from '../disasm';
+import { abiFromBytecode, disasm } from '../disasm';
 
 //const address = "0xbadc0defafcf6d4239bdf0b66da4d7bd36fcf05a";
 //const missingSelector = "0x69277b67";
@@ -22,6 +22,18 @@ test('code with deploy init', () => {
   r.sort();
 
   expect(r).toEqual(["0x29e46078", "0x4e148ce1", "0x68e5c066", "0xa87d942c"]);
+})
+
+test('creation bytecode keeps runtime-relative offsets', () => {
+  const wrap = (runtime: string) => {
+    const length = (runtime.length / 2).toString(16).padStart(2, "0");
+    return `60${length}600c60003960${length}6000f3${runtime}`;
+  };
+  const mutabilityRuntime = "60003560e01c63abcdef0114601357600080fd5b348015601d575f80fd5b6021565b5f5f5500";
+  const branchedRuntime = "806380000000106015578063aaaaaaaa14602957005b8063bbbbbbbb14602b5700" + "00".repeat(8) + "5b005b00";
+
+  expect(abiFromBytecode(wrap(mutabilityRuntime))).toEqual(abiFromBytecode(mutabilityRuntime));
+  expect(selectorsFromBytecode(wrap(branchedRuntime))).toEqual(selectorsFromBytecode(branchedRuntime));
 })
 
 test('code with non payable guard before router', () => {

--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -53,6 +53,19 @@ describe('proxy detection', () => {
         expect(program.proxies[0]).toBeInstanceOf(proxies.SequenceWalletProxyResolver);
     });
 
+    test('SequenceWallet Proxy: uses a prefixed address-keyed slot', async () => {
+        const address = "0x00Cd000000000000000000000000000000001234";
+        const resolver = new proxies.SequenceWalletProxyResolver();
+        const provider = {
+            getStorageAt: async (_address: string, slot: number | string) => {
+                expect(slot).toBe("0xcd000000000000000000000000000000001234");
+                return "0x" + "00".repeat(32);
+            },
+        };
+
+        await resolver.resolve(provider, address);
+    });
+
     test('Gnosis Safe Proxy Factory', async () => {
         // https://eips.ethereum.org/EIPS/eip-1167
         const bytecode = "0x608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032";

--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -265,20 +265,24 @@ describe('metadata extraction', () => {
 });
 
 describe('known proxy resolving', () => {
-    test('Diamond Proxy: ABI-pads the loupe selector argument', async () => {
+    test('Diamond Proxy: ABI-pads selector arguments and ignores empty responses', async () => {
         const selector = "0x12345678";
-        let calldata = "";
+        const calldata: string[] = [];
         const provider = {
             getStorageAt: async () => "0x" + "00".repeat(32),
             call: async (tx: { data: string }) => {
-                calldata = tx.data;
-                return "0x" + "00".repeat(12) + "11".repeat(20);
+                calldata.push(tx.data);
+                return calldata.length === 1 ? "0x" : "0x" + "00".repeat(12) + "11".repeat(20);
             },
         };
 
-        await new proxies.DiamondProxyResolver("DiamondProxy").resolve(provider, "0x" + "22".repeat(20), selector);
+        const got = await new proxies.DiamondProxyResolver("DiamondProxy").resolve(provider, "0x" + "22".repeat(20), selector);
 
-        expect(calldata).toBe("0xcdffacc6" + selector.slice(2).padEnd(64, "0"));
+        expect(calldata).toEqual([
+            "0xcdffacc6" + selector.slice(2).padEnd(64, "0"),
+            "0x0d741577" + selector.slice(2).padEnd(64, "0"),
+        ]);
+        expect(got).toBe("0x" + "11".repeat(20));
     });
 
     online_test('Safe: Proxy Factory 1.1.1', async ({ provider }) => {

--- a/src/__tests__/proxies.test.ts
+++ b/src/__tests__/proxies.test.ts
@@ -265,6 +265,22 @@ describe('metadata extraction', () => {
 });
 
 describe('known proxy resolving', () => {
+    test('Diamond Proxy: ABI-pads the loupe selector argument', async () => {
+        const selector = "0x12345678";
+        let calldata = "";
+        const provider = {
+            getStorageAt: async () => "0x" + "00".repeat(32),
+            call: async (tx: { data: string }) => {
+                calldata = tx.data;
+                return "0x" + "00".repeat(12) + "11".repeat(20);
+            },
+        };
+
+        await new proxies.DiamondProxyResolver("DiamondProxy").resolve(provider, "0x" + "22".repeat(20), selector);
+
+        expect(calldata).toBe("0xcdffacc6" + selector.slice(2).padEnd(64, "0"));
+    });
+
     online_test('Safe: Proxy Factory 1.1.1', async ({ provider }) => {
         const address = "0x655a9e6b044d6b62f393f9990ec3ea877e966e18";
         // Need to call masterCopy() or getStorageAt for 0th slot

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -156,6 +156,10 @@ export type AutoloadConfig = {
  * ```
  */
 export async function autoload(address: string, config: AutoloadConfig): Promise<AutoloadResult> {
+    return await _autoload(address, config, new Set());
+}
+
+async function _autoload(address: string, config: AutoloadConfig, visitedAddresses: ReadonlySet<string>): Promise<AutoloadResult> {
     if (config === undefined) {
         throw new errors.AutoloadError("config is undefined, must include 'provider'");
     }
@@ -189,6 +193,9 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
             }
         }
     }
+
+    const proxyPath = new Set(visitedAddresses);
+    proxyPath.add(address.toLowerCase());
 
     // Load code, we need to disasm to find proxies
     onProgress("getCode", { address });
@@ -231,7 +238,15 @@ export async function autoload(address: string, config: AutoloadConfig): Promise
             for (const resolver of result.proxies) {
                 onProgress("followProxies", { resolver: resolver, address });
                 const resolved = await resolver.resolve(provider, address, selector);
-                if (resolved !== undefined) return await autoload(resolved, config);
+                if (resolved !== undefined) {
+                    if (proxyPath.has(resolved.toLowerCase())) {
+                        onError("followProxies", new errors.AutoloadError(`Proxy cycle detected while resolving ${address}`, {
+                            context: { address, resolved },
+                        }));
+                        return result;
+                    }
+                    return await _autoload(resolved, config, proxyPath);
+                }
             }
             onError("followProxies", new Error("failed to resolve proxy"));
             return result;

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -16,6 +16,7 @@ import { MultiABILoader } from "./loaders.js";
 /// Magic number we use to determine whether a proxy is reasonably a destination contract or not.
 /// If it has many SSTORE's then it's probably doing something other than proxying.
 const PROXY_SSTORE_COUNT_MAX = 4;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 function isAddress(address: string) {
     return address.length === 42 && address.startsWith("0x") && Number(address) >= 0;
@@ -238,7 +239,7 @@ async function _autoload(address: string, config: AutoloadConfig, visitedAddress
             for (const resolver of result.proxies) {
                 onProgress("followProxies", { resolver: resolver, address });
                 const resolved = await resolver.resolve(provider, address, selector);
-                if (resolved !== undefined) {
+                if (resolved !== undefined && resolved !== ZERO_ADDRESS) {
                     if (proxyPath.has(resolved.toLowerCase())) {
                         onError("followProxies", new errors.AutoloadError(`Proxy cycle detected while resolving ${address}`, {
                             context: { address, resolved },

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -312,7 +312,7 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
                 if (checkJumpTable && Object.keys(p.selectors).length > 0) {
                     checkJumpTable = false;
                 }
-                if (resumeJumpTable.delete(pos)) {
+                if (resumeJumpTable.delete(pos - runtimeOffset)) {
                     // Continuation of a previous jump table?
                     // Selector branch trees start by pushing CALLDATALOAD or it was pushed before.
                     checkJumpTable = code.at(pos + 1) === opcodes.DUP1 || code.at(pos + 1) === opcodes.CALLDATALOAD;
@@ -337,7 +337,7 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
                 code.at(pos + 2) === opcodes.DUP1 &&
                 code.at(pos + 3) === opcodes.ISZERO
             ) {
-                p.notPayable[pos] = step;
+                p.notPayable[pos - runtimeOffset] = step;
                 // TODO: Optimization: Could seek ahead 3 pos/count safely
             }
 
@@ -361,7 +361,7 @@ export function disasm(bytecode: string, config?: {onlyJumpTable: boolean}): Pro
             // Detect simple JUMP/JUMPI helper subroutines
             if ((inst === opcodes.JUMP || inst === opcodes.JUMPI) && isPush(code.at(-2))) {
                 const jumpOffset = valueToOffset(code.valueAt(-2));
-                currentFunction.jumps.push(jumpOffset - runtimeOffset);
+                currentFunction.jumps.push(jumpOffset);
                 maxJumpDest = Math.max(maxJumpDest, jumpOffset);
             }
 

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -297,7 +297,9 @@ export class SequenceWalletProxyResolver extends BaseProxyResolver implements Pr
     override name = "SequenceWalletProxy";
 
     async resolve(provider: StorageProvider, address: string): Promise<string> {
-        return addressFromPadded(await provider.getStorageAt(address, address.toLowerCase().slice(2)));
+        // JSON-RPC quantities require a 0x prefix and no leading zeros.
+        const slot = "0x" + BigInt(address).toString(16);
+        return addressFromPadded(await provider.getStorageAt(address, slot));
     }
 }
 

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -66,7 +66,7 @@ const _zeroAddress = "0x0000000000000000000000000000000000000000";
 
 // Convert 32 byte hex to a 20 byte hex address
 function addressFromPadded(data:string): string {
-    return "0x" + data.slice(data.length - 40);
+    return "0x" + wordFrom(data).slice(-40);
 }
 
 

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -187,7 +187,7 @@ export class DiamondProxyResolver extends BaseProxyResolver implements ProxyReso
             try {
                 const addr = addressFromPadded(await provider.call({
                     to: address,
-                    data: facetSelector + selector,
+                    data: facetSelector + selector.padEnd(64, "0"),
                 }));
                 if (addr !== _zeroAddress) return addr;
             } catch (e: any) {


### PR DESCRIPTION
  - Prevent recursive proxy cycles during autoload by tracking visited addresses and returning the current result when a cycle is detected.
  - Do not follow proxy resolutions that return the zero address.
  - Normalize creation-bytecode offsets so jump tables, jump destinations, and non-payable annotations remain runtime-relative.
  - Canonicalize Sequence wallet address-derived storage slots as valid JSON-RPC quantities.
  - ABI-pad Diamond loupe selector arguments to a full 32-byte word.
  - Normalize short or empty provider words before extracting addresses, making "0x" resolve to the zero address instead of malformed "0x0x".
  - Add focused regression coverage for each behavior, largely by extending existing tests.